### PR TITLE
Fix orchestrator MCP usage and add missing agent base

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -118,7 +118,8 @@ class GenesisOrchestrator:
         
         # Inicializar protocolo MCP
         if not self.mcp.running:
-            await self.mcp.start()
+            # MCPProtocol.start is synchronous
+            self.mcp.start()
         
         # Registrar agentes especializados
         await self._register_agents()
@@ -455,11 +456,11 @@ class GenesisOrchestrator:
             )
             
             # Enviar solicitud al agente
-            response = await self.mcp.send_request(
-                sender="orchestrator",
-                recipient=step.agent_id,
+            response = self.mcp.send_request(
+                sender_id="orchestrator",
+                target_id=step.agent_id,
                 action="task.execute",
-                params={
+                data={
                     "task_id": task.id,
                     "name": task.name,
                     "description": task.description,
@@ -650,7 +651,7 @@ Generado con ❤️ por Genesis Engine
         for agent in self.agents.values():
             await agent.stop()
         
-        # Detener protocolo MCP
-        await self.mcp.stop()
+        # Detener protocolo MCP (síncrono)
+        self.mcp.stop()
         
         self.logger.info("🛑 Orchestrator detenido")

--- a/mcp/agent_base.py
+++ b/mcp/agent_base.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+"""Base classes and dataclasses for Genesis agents used by the MCP protocol."""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+import asyncio
+import uuid
+
+from genesis_engine.mcp.message_types import MCPRequest
+from genesis_engine.agents.base_agent import BaseAgent
+
+@dataclass
+class AgentTask:
+    """Representation of a task assigned to an agent."""
+    id: str
+    name: str
+    description: str = ""
+    params: Dict[str, Any] = field(default_factory=dict)
+    priority: int = 0
+
+@dataclass
+class TaskResult:
+    """Result returned by an agent after executing a task."""
+    task_id: str
+    success: bool
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+class GenesisAgent(BaseAgent):
+    """Base class for all Genesis Engine agents."""
+
+    def __init__(self, agent_id: str, name: str, agent_type: str, version: str = "1.0.0"):
+        super().__init__(name=name, version=version)
+        self.agent_id = agent_id or f"{agent_type}_{uuid.uuid4().hex[:8]}"
+        self.agent_type = agent_type
+        self.handlers: Dict[str, Callable] = {}
+        self.metadata: Dict[str, Any] = {}
+
+    async def start(self):
+        """Initialize the agent."""
+        self.status = "running"
+
+    async def stop(self):
+        """Stop the agent."""
+        self.status = "stopped"
+
+    def add_capability(self, capability: str):
+        if capability not in self.capabilities:
+            self.capabilities.append(capability)
+
+    def register_handler(self, action: str, handler: Callable):
+        self.handlers[action] = handler
+
+    def set_metadata(self, key: str, value: Any):
+        self.metadata[key] = value
+
+    def get_metadata(self, key: str, default: Any = None) -> Any:
+        return self.metadata.get(key, default)
+
+    def get_capabilities(self) -> list:
+        return list(self.capabilities)
+
+    def handle_request(self, request: MCPRequest) -> Dict[str, Any]:
+        handler = self.handlers.get(request.action)
+        if not handler:
+            raise ValueError(f"Handler not found for action '{request.action}'")
+
+        if asyncio.iscoroutinefunction(handler):
+            return asyncio.run(handler(request.data))
+        return handler(request.data)


### PR DESCRIPTION
## Summary
- implement missing `mcp/agent_base.py` with `GenesisAgent`, `AgentTask`, and `TaskResult`
- fix orchestrator to call MCP protocol synchronously

## Testing
- `python -m py_compile core/orchestrator.py mcp/agent_base.py`

------
https://chatgpt.com/codex/tasks/task_e_686af9780c60832598416caddb11b86b