### PR TITLE
Fix CLI utils import

### DIFF
--- a/genesis_engine/cli/main.py
+++ b/genesis_engine/cli/main.py
@@ -16,7 +16,7 @@ from genesis_engine.cli.commands.init import init_command
 from genesis_engine.cli.commands.doctor import doctor_command
 from genesis_engine.cli.commands.deploy import deploy_command
 from genesis_engine.cli.commands.generate import generate_command
-from genesis_engine.cli.utils import show_banner, check_dependencies
+from genesis_engine.cli.commands.utils import show_banner, check_dependencies
 from genesis_engine import __version__
 
 # Configurar Rich Console


### PR DESCRIPTION
## Summary
- fix path to utils module in CLI main entrypoint

## Testing
- `poetry run genesis --version`
- `poetry run genesis doctor`


------
https://chatgpt.com/codex/tasks/task_e_686b0d26d4008325b66353f683306f66