### PR TITLE
Expose CLI utilities

### DIFF
--- a/genesis_engine/cli/__init__.py
+++ b/genesis_engine/cli/__init__.py
@@ -1,1 +1,5 @@
-"""Genesis Engine module"""
+"""Genesis Engine CLI package."""
+
+from .utils import show_banner, check_dependencies
+
+__all__ = ["show_banner", "check_dependencies"]

--- a/genesis_engine/cli/utils.py
+++ b/genesis_engine/cli/utils.py
@@ -1,0 +1,5 @@
+"""Helper functions for the Genesis Engine CLI."""
+
+from .commands.utils import show_banner, check_dependencies
+
+__all__ = ["show_banner", "check_dependencies"]


### PR DESCRIPTION
## Summary
- add a small utils module in `genesis_engine.cli`
- re-export `show_banner` and `check_dependencies`
- expose these helpers from the CLI package

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0fb5c4108325a7e12be8e0ca467b