### PR TITLE
Add help command and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ genesis doctor
 
 ## 🎯 Uso Básico
 
+### Mostrar Ayuda
+
+```bash
+genesis help
+```
+
 ### Crear Proyecto con Golden Path (SaaS Básico)
 
 ```bash

--- a/genesis_engine/cli/main.py
+++ b/genesis_engine/cli/main.py
@@ -246,6 +246,19 @@ def agents(
     else:
         console.print("[yellow]💡 Usa --list para ver agentes disponibles[/yellow]")
 
+
+@app.command("help")
+def help_cmd():
+    """Mostrar la ayuda completa de la CLI"""
+    try:
+        typer.echo(app.get_help())
+    except AttributeError:
+        from typer.main import get_command
+        import click
+        cmd = get_command(app)
+        ctx = click.Context(cmd)
+        typer.echo(cmd.get_help(ctx))
+
 # Punto de entrada principal
 def main_entry():
     """Entry point principal para el script de consola"""

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+import types
+import importlib.util
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_help_command(capsys):
+    # Prepare minimal genesis_engine package for imports
+    pkg = types.ModuleType('genesis_engine')
+    pkg.__path__ = [str(ROOT)]
+    pkg.__version__ = '0.0.0'
+    sys.modules['genesis_engine'] = pkg
+
+    spec = importlib.util.spec_from_file_location(
+        'genesis_engine.cli.main', ROOT / 'genesis_engine' / 'cli' / 'main.py'
+    )
+    cli_main = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli_main)
+
+    cli_main.app(["help"], standalone_mode=False)
+    captured = capsys.readouterr()
+    assert "Usage" in captured.out
+
+    del sys.modules['genesis_engine']


### PR DESCRIPTION
## Summary
- expose a `help` command from `genesis_engine.cli.main`
- document using `genesis help`
- verify help command via new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b19000c388325b00753d6c84fc625