### PR TITLE
Add SaaS basic template skeleton

### DIFF
--- a/genesis_engine.egg-info/SOURCES.txt
+++ b/genesis_engine.egg-info/SOURCES.txt
@@ -42,8 +42,6 @@ genesis_engine/mcp/message_types.py
 genesis_engine/mcp/protocol.py
 genesis_engine/templates/__init__.py
 genesis_engine/templates/engine.py
-genesis_engine/templates/__pycache__/__init__.cpython-311.pyc
-genesis_engine/templates/__pycache__/engine.cpython-311.pyc
 genesis_engine/templates/backend/fastapi/Dockerfile.j2
 genesis_engine/templates/backend/fastapi/database.py.j2
 genesis_engine/templates/backend/fastapi/main.py.j2
@@ -51,6 +49,8 @@ genesis_engine/templates/backend/fastapi/requirements.txt.j2
 genesis_engine/templates/backend/fastapi/models/model.py.j2
 genesis_engine/templates/backend/fastapi/routes/router.py.j2
 genesis_engine/templates/backend/fastapi/schemas/schema.py.j2
+genesis_engine/templates/devops/docker-compose.yml.j2
+genesis_engine/templates/devops/github/ci.yml.j2
 genesis_engine/templates/frontend/nextjs/a.ts
 genesis_engine/templates/frontend/nextjs/next.config.js.j2
 genesis_engine/templates/frontend/nextjs/package.json.j2
@@ -65,5 +65,13 @@ genesis_engine/templates/frontend/nextjs/lib/api/client.ts.j2
 genesis_engine/templates/frontend/nextjs/lib/slices/authSlice.ts.j2
 genesis_engine/utils/__init__.py
 genesis_engine/utils/validation.py
+tests/test_agents_instantiation.py
+tests/test_architect_agent.py
+tests/test_cli.py
+tests/test_cli_help.py
 tests/test_orchestrator.py
 tests/test_template_engine.py
+genesis_engine/templates/saas-basic/README.md.j2
+genesis_engine/templates/saas-basic/backend/README.md.j2
+genesis_engine/templates/saas-basic/frontend/README.md.j2
+genesis_engine/templates/saas-basic/devops/README.md.j2

--- a/genesis_engine/cli/commands/init.py
+++ b/genesis_engine/cli/commands/init.py
@@ -57,6 +57,16 @@ def init_command(
         "version": "1.0.0",
         "description": f"Aplicación {template} generada con Genesis Engine"
     }
+
+    if template == "saas-basic" and no_interactive:
+        project_config["backend"] = {
+            "framework": "fastapi",
+            "database": "postgresql"
+        }
+        project_config["frontend"] = {
+            "framework": "nextjs",
+            "styling": "tailwind"
+        }
     
     if not no_interactive:
         console.print("\n[bold]📋 Configuración del Proyecto[/bold]")
@@ -129,11 +139,20 @@ def init_command(
         # Crear directorio del proyecto
         project_dir.mkdir(parents=True, exist_ok=True)
         
+        # Preparar contexto para las plantillas
+        context = {
+            **project_config,
+            "project_name": project_config.get("name"),
+            "backend_framework": project_config.get("backend", {}).get("framework", "fastapi"),
+            "frontend_framework": project_config.get("frontend", {}).get("framework", "nextjs"),
+            "database_type": project_config.get("backend", {}).get("database", "postgresql"),
+        }
+
         # Generar archivos usando template engine
         template_engine.generate_project(
             template_name=template,
             output_dir=project_dir,
-            context=project_config
+            context=context
         )
         
         progress.update(task3, completed=1)

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -106,9 +106,15 @@ class TemplateEngine:
         """Configurar filtros personalizados"""
         self._custom_filters.update({
             'camelcase': self._camel_case,
+            'camel_case': self._camel_case,
             'snakecase': self._snake_case,
+            'snake_case': self._snake_case,
             'kebabcase': self._kebab_case,
+            'kebab_case': self._kebab_case,
             'pascalcase': self._pascal_case,
+            'pascal_case': self._pascal_case,
+            'plural': self._pluralize,
+            'singular': self._singularize,
             'sqltype': self._get_sql_type,
             'tstype': self._get_typescript_type,
             'pytype': self._get_python_type,

--- a/genesis_engine/templates/saas-basic/README.md.j2
+++ b/genesis_engine/templates/saas-basic/README.md.j2
@@ -1,0 +1,7 @@
+# {{ project_name }}
+
+{{ description }}
+
+Generated on {{ generated_at }} using Genesis Engine SaaS Basic template.
+
+This skeleton references the FastAPI backend and Next.js frontend templates.

--- a/genesis_engine/templates/saas-basic/backend/README.md.j2
+++ b/genesis_engine/templates/saas-basic/backend/README.md.j2
@@ -1,0 +1,4 @@
+# Backend
+
+Base structure for a FastAPI application.
+Refer to `templates/backend/fastapi` for full templates.

--- a/genesis_engine/templates/saas-basic/devops/README.md.j2
+++ b/genesis_engine/templates/saas-basic/devops/README.md.j2
@@ -1,0 +1,3 @@
+# DevOps
+
+Docker Compose and GitHub Actions examples are available in the devops templates.

--- a/genesis_engine/templates/saas-basic/frontend/README.md.j2
+++ b/genesis_engine/templates/saas-basic/frontend/README.md.j2
@@ -1,0 +1,4 @@
+# Frontend
+
+Base structure for a Next.js application.
+Refer to `templates/frontend/nextjs` for full templates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,4 +46,8 @@ where = ["."]
 include = ["genesis_engine*"]
 
 [tool.setuptools.package-data]
-genesis_engine = ["templates/**/*", "templates/**/**/*"]
+genesis_engine = [
+    "templates/**/*",
+    "templates/**/**/*",
+    "templates/saas-basic/**/*"
+]


### PR DESCRIPTION
## Summary
- add new `saas-basic` template with simple README files
- register new template path in packaging config
- support snake_case and other filters aliases
- provide default stack values during `genesis init`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'genesis_engine.mcp.protocol')*
- `python -m genesis_engine.cli.main init testproj --no-interactive`

------
https://chatgpt.com/codex/tasks/task_e_686b1fc3d87483259536cf6ea95aaeb6