### PR TITLE
Refactor MCP protocol to asyncio

### DIFF
--- a/genesis_engine/agents/base_agent.py
+++ b/genesis_engine/agents/base_agent.py
@@ -56,7 +56,7 @@ class BaseAgent(ABC):
         """
         pass
     
-    def send_request(
+    async def send_request(
         self,
         target_agent: str,
         action: str,
@@ -66,8 +66,8 @@ class BaseAgent(ABC):
         """Enviar solicitud a otro agente"""
         if not self.mcp_protocol:
             raise RuntimeError("Protocolo MCP no configurado")
-        
-        return self.mcp_protocol.send_request(
+
+        return await self.mcp_protocol.send_request(
             sender_id=self.agent_id,
             target_id=target_agent,
             action=action,

--- a/genesis_engine/core/orchestrator.py
+++ b/genesis_engine/core/orchestrator.py
@@ -119,8 +119,7 @@ class GenesisOrchestrator:
         
         # Inicializar protocolo MCP
         if not self.mcp.running:
-            # MCPProtocol.start is synchronous
-            self.mcp.start()
+            await self.mcp.start()
         
         # Registrar agentes especializados
         await self._register_agents()
@@ -492,7 +491,7 @@ class GenesisOrchestrator:
             )
             
             # Enviar solicitud al agente
-            response = self.mcp.send_request(
+            response = await self.mcp.send_request(
                 sender_id="orchestrator",
                 target_id=step.agent_id,
                 action="task.execute",
@@ -687,7 +686,7 @@ Generado con ❤️ por Genesis Engine
         for agent in self.agents.values():
             await agent.stop()
         
-        # Detener protocolo MCP (síncrono)
-        self.mcp.stop()
+        # Detener protocolo MCP
+        await self.mcp.stop()
         
         self.logger.info("🛑 Orchestrator detenido")


### PR DESCRIPTION
## Summary
- modernize message processing using asyncio
- use `asyncio.Queue` instead of `queue.Queue`
- await responses with `asyncio.Future` and `asyncio.wait_for`
- update orchestrator and agent base classes to work with async protocol

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b29cbb574832595da4243a41d3728