### PR TITLE
Handle unimplemented methods in agents

### DIFF
--- a/genesis_engine/agents/backend.py
+++ b/genesis_engine/agents/backend.py
@@ -101,17 +101,27 @@ class BackendAgent(GenesisAgent):
         self.template_engine = TemplateEngine()
         
         # Configuraciones por framework
-        self.framework_configs = self._load_framework_configs()
+        try:
+            self.framework_configs = self._load_framework_configs()
+        except NotImplementedError:
+            self.logger.warning("Framework config loader not implemented")
+            self.framework_configs = {}
         
     async def initialize(self):
         """Inicialización del agente backend"""
         self.logger.info("⚙️ Inicializando Backend Agent")
         
         # Cargar templates de código
-        await self._load_code_templates()
-        
+        try:
+            await self._load_code_templates()
+        except NotImplementedError:
+            self.logger.warning("Code template loading not implemented")
+
         # Configurar generadores específicos
-        await self._setup_code_generators()
+        try:
+            await self._setup_code_generators()
+        except NotImplementedError:
+            self.logger.warning("Code generators setup not implemented")
         
         self.set_metadata("version", "1.0.0")
         self.set_metadata("supported_frameworks", list(BackendFramework))
@@ -671,68 +681,68 @@ class BackendAgent(GenesisAgent):
     # Métodos auxiliares que se implementarían completamente
     def _load_framework_configs(self) -> Dict[str, Any]:
         """Cargar configuraciones por framework"""
-        return {}
+        raise NotImplementedError("_load_framework_configs not implemented")
     
     async def _load_code_templates(self):
         """Cargar templates de código"""
-        pass
+        raise NotImplementedError("_load_code_templates not implemented")
     
     async def _setup_code_generators(self):
         """Configurar generadores de código"""
-        pass
+        raise NotImplementedError("_setup_code_generators not implemented")
     
     async def _generate_typeorm_entity(self, entity: Dict[str, Any], output_path: Path, config: BackendConfig) -> str:
         """Generar entidad TypeORM"""
-        return ""
+        raise NotImplementedError("_generate_typeorm_entity not implemented")
     
     async def _generate_nestjs_controller(self, entity: Dict[str, Any], output_path: Path, config: BackendConfig) -> str:
         """Generar controlador NestJS"""
-        return ""
+        raise NotImplementedError("_generate_nestjs_controller not implemented")
     
     async def _generate_main_routes(self, entities: List[Dict[str, Any]], output_path: Path, config: BackendConfig) -> str:
         """Generar archivo principal de rutas"""
-        return ""
+        raise NotImplementedError("_generate_main_routes not implemented")
     
     async def _generate_sqlalchemy_config(self, output_path: Path, config: BackendConfig) -> str:
         """Generar configuración SQLAlchemy"""
-        return ""
+        raise NotImplementedError("_generate_sqlalchemy_config not implemented")
     
     async def _setup_alembic_migrations(self, output_path: Path, config: BackendConfig, schema: Dict[str, Any]) -> List[str]:
         """Configurar migraciones Alembic"""
-        return []
+        raise NotImplementedError("_setup_alembic_migrations not implemented")
     
     async def _generate_typeorm_config(self, output_path: Path, config: BackendConfig) -> str:
         """Generar configuración TypeORM"""
-        return ""
+        raise NotImplementedError("_generate_typeorm_config not implemented")
     
     async def _generate_fastapi_jwt_auth(self, output_path: Path, config: BackendConfig) -> List[str]:
         """Generar autenticación JWT para FastAPI"""
-        return []
+        raise NotImplementedError("_generate_fastapi_jwt_auth not implemented")
     
     async def _generate_nestjs_jwt_auth(self, output_path: Path, config: BackendConfig) -> List[str]:
         """Generar autenticación JWT para NestJS"""
-        return []
+        raise NotImplementedError("_generate_nestjs_jwt_auth not implemented")
     
     async def _generate_python_requirements(self, output_path: Path, config: BackendConfig) -> str:
         """Generar requirements.txt"""
-        return ""
+        raise NotImplementedError("_generate_python_requirements not implemented")
     
     async def _generate_env_template(self, output_path: Path, config: BackendConfig) -> str:
         """Generar template .env"""
-        return ""
+        raise NotImplementedError("_generate_env_template not implemented")
     
     async def _generate_dockerfile_python(self, output_path: Path, config: BackendConfig) -> str:
         """Generar Dockerfile para Python"""
-        return ""
+        raise NotImplementedError("_generate_dockerfile_python not implemented")
     
     async def _generate_package_json(self, output_path: Path, config: BackendConfig, schema: Dict[str, Any]) -> str:
         """Generar package.json"""
-        return ""
+        raise NotImplementedError("_generate_package_json not implemented")
     
     async def _generate_dockerfile_node(self, output_path: Path, config: BackendConfig) -> str:
         """Generar Dockerfile para Node.js"""
-        return ""
+        raise NotImplementedError("_generate_dockerfile_node not implemented")
     
     async def _generate_api_documentation(self, params: Dict[str, Any]) -> List[str]:
         """Generar documentación de API"""
-        return []
+        raise NotImplementedError("_generate_api_documentation not implemented")

--- a/genesis_engine/agents/devops.py
+++ b/genesis_engine/agents/devops.py
@@ -95,7 +95,10 @@ class DevOpsAgent(GenesisAgent):
         self.logger.info("🐳 Inicializando DevOps Agent")
         
         # Cargar templates de DevOps
-        await self._load_devops_templates()
+        try:
+            await self._load_devops_templates()
+        except NotImplementedError:
+            self.logger.warning("DevOps templates loader not implemented")
         
         self.set_metadata("version", "1.0.0")
         self.set_metadata("specialization", "containerization_and_deployment")
@@ -508,108 +511,108 @@ class DevOpsAgent(GenesisAgent):
     # Métodos auxiliares (implementación completa en producción)
     async def _load_devops_templates(self):
         """Cargar templates de DevOps"""
-        pass
+        raise NotImplementedError("_load_devops_templates not implemented")
     
     async def _generate_python_dockerfile(self, output_path: Path, service_name: str) -> str:
         """Generar Dockerfile para Python/FastAPI"""
-        return ""
+        raise NotImplementedError("_generate_python_dockerfile not implemented")
     
     async def _generate_node_dockerfile(self, output_path: Path, service_name: str) -> str:
         """Generar Dockerfile para Node.js"""
-        return ""
+        raise NotImplementedError("_generate_node_dockerfile not implemented")
     
     async def _generate_nextjs_dockerfile(self, output_path: Path) -> str:
         """Generar Dockerfile para Next.js"""
-        return ""
+        raise NotImplementedError("_generate_nextjs_dockerfile not implemented")
     
     async def _generate_dockerignore_files(self, output_path: Path, stack: Dict[str, str]) -> List[str]:
         """Generar archivos .dockerignore"""
-        return []
+        raise NotImplementedError("_generate_dockerignore_files not implemented")
     
     async def _generate_github_cd_workflow(self, workflows_dir: Path, schema: Dict[str, Any], config: DevOpsConfig) -> str:
         """Generar workflow de CD para GitHub Actions"""
-        return ""
+        raise NotImplementedError("_generate_github_cd_workflow not implemented")
     
     async def _generate_github_pr_workflow(self, workflows_dir: Path, schema: Dict[str, Any]) -> str:
         """Generar workflow de PR para GitHub Actions"""
-        return ""
+        raise NotImplementedError("_generate_github_pr_workflow not implemented")
     
     async def _generate_gitlab_ci(self, output_path: Path, schema: Dict[str, Any], config: DevOpsConfig) -> str:
         """Generar configuración de GitLab CI"""
-        return ""
+        raise NotImplementedError("_generate_gitlab_ci not implemented")
     
     async def _generate_k8s_namespace(self, output_path: Path, schema: Dict[str, Any]) -> str:
         """Generar namespace de Kubernetes"""
-        return ""
+        raise NotImplementedError("_generate_k8s_namespace not implemented")
     
     async def _generate_k8s_configmaps(self, output_path: Path, schema: Dict[str, Any]) -> str:
         """Generar ConfigMaps de Kubernetes"""
-        return ""
+        raise NotImplementedError("_generate_k8s_configmaps not implemented")
     
     async def _generate_k8s_secrets(self, output_path: Path, schema: Dict[str, Any]) -> str:
         """Generar Secrets de Kubernetes"""
-        return ""
+        raise NotImplementedError("_generate_k8s_secrets not implemented")
     
     async def _generate_k8s_backend_deployment(self, output_path: Path, schema: Dict[str, Any]) -> str:
         """Generar deployment del backend"""
-        return ""
+        raise NotImplementedError("_generate_k8s_backend_deployment not implemented")
     
     async def _generate_k8s_frontend_deployment(self, output_path: Path, schema: Dict[str, Any]) -> str:
         """Generar deployment del frontend"""
-        return ""
+        raise NotImplementedError("_generate_k8s_frontend_deployment not implemented")
     
     async def _generate_k8s_database_deployment(self, output_path: Path, schema: Dict[str, Any]) -> str:
         """Generar deployment de la base de datos"""
-        return ""
+        raise NotImplementedError("_generate_k8s_database_deployment not implemented")
     
     async def _generate_k8s_services(self, output_path: Path, schema: Dict[str, Any]) -> str:
         """Generar Services de Kubernetes"""
-        return ""
+        raise NotImplementedError("_generate_k8s_services not implemented")
     
     async def _generate_k8s_ingress(self, output_path: Path, schema: Dict[str, Any], config: DevOpsConfig) -> str:
         """Generar Ingress de Kubernetes"""
-        return ""
+        raise NotImplementedError("_generate_k8s_ingress not implemented")
     
     async def _generate_k8s_hpa(self, output_path: Path, schema: Dict[str, Any]) -> str:
         """Generar HorizontalPodAutoscaler"""
-        return ""
+        raise NotImplementedError("_generate_k8s_hpa not implemented")
     
     async def _generate_deployment_scripts(self, output_path: Path, config: DevOpsConfig) -> List[str]:
         """Generar scripts de despliegue"""
-        return []
+        raise NotImplementedError("_generate_deployment_scripts not implemented")
     
     async def _generate_backup_scripts(self, output_path: Path, config: DevOpsConfig) -> List[str]:
         """Generar scripts de backup"""
-        return []
+        raise NotImplementedError("_generate_backup_scripts not implemented")
     
     async def _generate_security_config(self, output_path: Path, config: DevOpsConfig) -> List[str]:
         """Generar configuración de seguridad"""
-        return []
+        raise NotImplementedError("_generate_security_config not implemented")
     
     async def _generate_prometheus_config(self, output_path: Path) -> str:
         """Generar configuración de Prometheus"""
-        return ""
+        raise NotImplementedError("_generate_prometheus_config not implemented")
     
     async def _generate_grafana_dashboards(self, output_path: Path) -> List[str]:
         """Generar dashboards de Grafana"""
-        return []
+        raise NotImplementedError("_generate_grafana_dashboards not implemented")
     
     async def _generate_alertmanager_config(self, output_path: Path) -> str:
         """Generar configuración de Alertmanager"""
-        return ""
+        raise NotImplementedError("_generate_alertmanager_config not implemented")
     
     async def _generate_monitoring_compose(self, output_path: Path) -> str:
         """Generar docker-compose para monitoreo"""
-        return ""
+        raise NotImplementedError("_generate_monitoring_compose not implemented")
     
     async def _generate_main_nginx_conf(self, nginx_dir: Path, config: DevOpsConfig, schema: Dict[str, Any]) -> str:
         """Generar nginx.conf principal"""
-        return ""
+        raise NotImplementedError("_generate_main_nginx_conf not implemented")
     
     async def _generate_site_nginx_conf(self, nginx_dir: Path, config: DevOpsConfig, schema: Dict[str, Any]) -> str:
         """Generar configuración del sitio"""
-        return ""
+        raise NotImplementedError("_generate_site_nginx_conf not implemented")
     
     async def _generate_ssl_nginx_conf(self, nginx_dir: Path) -> str:
         """Generar configuración SSL"""
-        return ""
+        raise NotImplementedError("_generate_ssl_nginx_conf not implemented")


### PR DESCRIPTION
## Summary
- handle missing framework configs in `BackendAgent`
- warn when backend init helpers aren't implemented
- raise `NotImplementedError` for backend helper stubs
- warn when DevOps templates are missing
- raise `NotImplementedError` for devops helper stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b29cc96dc8325aa9bbde243c71201