### PR TITLE
Centralize logging configuration

### DIFF
--- a/genesis_engine/core/logging.py
+++ b/genesis_engine/core/logging.py
@@ -1,0 +1,24 @@
+import logging
+from typing import Optional
+
+DEFAULT_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+DEFAULT_LEVEL = logging.INFO
+
+
+def configure_logging(level: int = DEFAULT_LEVEL, fmt: str = DEFAULT_FORMAT) -> None:
+    """Configure the root logger once with a standard stream handler."""
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(fmt))
+        root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+
+
+def get_logger(name: str, level: Optional[int] = None) -> logging.Logger:
+    """Return a logger configured with the global settings."""
+    configure_logging(level or DEFAULT_LEVEL)
+    logger = logging.getLogger(name)
+    if level is not None:
+        logger.setLevel(level)
+    return logger

--- a/genesis_engine/core/orchestrator.py
+++ b/genesis_engine/core/orchestrator.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass
 from enum import Enum
-import logging
+from genesis_engine.core.logging import get_logger
 
 from genesis_engine.mcp.protocol import mcp_protocol, MCPProtocol
 from genesis_engine.mcp.agent_base import AgentTask, TaskResult
@@ -84,7 +84,7 @@ class GenesisOrchestrator:
     def __init__(self):
         self.mcp = mcp_protocol
         self.project_manager = ProjectManager()
-        self.logger = self._setup_logger()
+        self.logger = get_logger("genesis.orchestrator")
         
         # Agentes registrados
         self.agents: Dict[str, Any] = {}
@@ -98,20 +98,6 @@ class GenesisOrchestrator:
         self.running = False
         self.cancelled = False
         
-    def _setup_logger(self) -> logging.Logger:
-        """Configurar logger del orquestador"""
-        logger = logging.getLogger("genesis.orchestrator")
-        logger.setLevel(logging.INFO)
-        
-        if not logger.handlers:
-            handler = logging.StreamHandler()
-            formatter = logging.Formatter(
-                '%(asctime)s - Orchestrator - %(levelname)s - %(message)s'
-            )
-            handler.setFormatter(formatter)
-            logger.addHandler(handler)
-        
-        return logger
     
     async def initialize(self):
         """Inicializar el orquestador"""

--- a/genesis_engine/core/project_manager.py
+++ b/genesis_engine/core/project_manager.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 from dataclasses import dataclass, asdict
 from datetime import datetime
-import logging
+from genesis_engine.core.logging import get_logger
 
 from genesis_engine.core.config import GenesisConfig
 
@@ -83,26 +83,12 @@ class ProjectManager:
         self.current_phase: Optional[str] = None
         
         # Logging
-        self.logger = self._setup_logger()
+        self.logger = get_logger("genesis.project_manager")
         
         # Validaciones
         self.validation_errors: List[str] = []
         self.validation_warnings: List[str] = []
     
-    def _setup_logger(self) -> logging.Logger:
-        """Configurar logger del project manager"""
-        logger = logging.getLogger("genesis.project_manager")
-        logger.setLevel(logging.INFO)
-        
-        if not logger.handlers:
-            handler = logging.StreamHandler()
-            formatter = logging.Formatter(
-                '%(asctime)s - ProjectManager - %(levelname)s - %(message)s'
-            )
-            handler.setFormatter(formatter)
-            logger.addHandler(handler)
-        
-        return logger
     
     async def initialize_project(
         self, 

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -16,7 +16,7 @@ import asyncio
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from datetime import datetime
-import logging
+from genesis_engine.core.logging import get_logger
 
 from jinja2 import Environment, FileSystemLoader, Template, TemplateError
 from jinja2.exceptions import TemplateNotFound, TemplateSyntaxError
@@ -32,7 +32,7 @@ class TemplateEngine:
     def __init__(self, templates_dir: Optional[Path] = None):
         self.templates_dir = templates_dir or self._get_default_templates_dir()
         self.env = self._setup_jinja_environment()
-        self.logger = self._setup_logger()
+        self.logger = get_logger("genesis.template_engine")
         
         # Cache de templates renderizados
         self._template_cache: Dict[str, Template] = {}
@@ -66,20 +66,6 @@ class TemplateEngine:
         
         return env
     
-    def _setup_logger(self) -> logging.Logger:
-        """Configurar logger"""
-        logger = logging.getLogger("genesis.template_engine")
-        logger.setLevel(logging.INFO)
-        
-        if not logger.handlers:
-            handler = logging.StreamHandler()
-            formatter = logging.Formatter(
-                '%(asctime)s - TemplateEngine - %(levelname)s - %(message)s'
-            )
-            handler.setFormatter(formatter)
-            logger.addHandler(handler)
-        
-        return logger
     
     def _setup_default_helpers(self):
         """Configurar funciones helper por defecto"""

--- a/genesis_engine/utils/validation.py
+++ b/genesis_engine/utils/validation.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass
 from enum import Enum
-import logging
+from genesis_engine.core.logging import get_logger
 import re
 
 class ValidationLevel(str, Enum):
@@ -48,14 +48,8 @@ class EnvironmentValidator:
     """
     
     def __init__(self):
-        self.logger = self._setup_logger()
+        self.logger = get_logger("genesis.validation")
         self.results: List[ValidationResult] = []
-    
-    def _setup_logger(self) -> logging.Logger:
-        """Configurar logger"""
-        logger = logging.getLogger("genesis.validation")
-        logger.setLevel(logging.INFO)
-        return logger
     
     def run_diagnostics(self) -> List[ValidationResult]:
         """
@@ -488,7 +482,7 @@ class ConfigValidator:
     """
     
     def __init__(self):
-        self.logger = logging.getLogger("genesis.config_validator")
+        self.logger = get_logger("genesis.config_validator")
     
     def validate_project_config(self, config: Dict[str, Any]) -> List[ValidationResult]:
         """
@@ -638,7 +632,7 @@ class SchemaValidator:
     """
     
     def __init__(self):
-        self.logger = logging.getLogger("genesis.schema_validator")
+        self.logger = get_logger("genesis.schema_validator")
     
     def validate_project_schema(self, schema: Dict[str, Any]) -> List[ValidationResult]:
         """


### PR DESCRIPTION
## Summary
- centralize logging configuration in `genesis_engine.core.logging`
- use new `get_logger` helper in orchestrator, project manager, template engine and validators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b29ccf68483258aea445a871e8b67