### PR TITLE
Implement dependency checks and tests

### DIFF
--- a/genesis_engine/cli/commands/doctor.py
+++ b/genesis_engine/cli/commands/doctor.py
@@ -11,6 +11,8 @@ from rich.table import Table
 from rich.panel import Panel
 from rich import print as rprint
 
+from genesis_engine.cli.commands.utils import check_dependencies
+
 console = Console()
 
 def doctor_command():
@@ -27,8 +29,14 @@ def doctor_command():
     table.add_column("Estado", style="magenta")
     table.add_column("Versión", style="green")
     table.add_column("Notas", style="yellow")
-    
+
     checks = []
+
+    try:
+        check_dependencies()
+    except RuntimeError as exc:
+        rprint(f"[red]{exc}[/red]")
+        return False
     
     # 1. Verificar Python
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"

--- a/genesis_engine/cli/commands/utils.py
+++ b/genesis_engine/cli/commands/utils.py
@@ -2,6 +2,9 @@
 Utilidades para CLI
 """
 
+import sys
+import subprocess
+
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
@@ -24,7 +27,36 @@ def show_banner():
         padding=(1, 2)
     ))
 
-def check_dependencies():
-    """Verificar dependencias básicas"""
-    # TODO: Implementar verificación de dependencias
-    pass
+def check_dependencies() -> bool:
+    """Verificar dependencias básicas.
+
+    Returns ``True`` si todas las dependencias están disponibles. Lanza un
+    ``RuntimeError`` si alguna está ausente o si la versión de Python es
+    inferior a 3.8.
+    """
+
+    missing = []
+
+    if sys.version_info < (3, 8):
+        missing.append("Python >= 3.8")
+
+    def _check(cmd, name):
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            return result.returncode == 0
+        except FileNotFoundError:
+            return False
+
+    if not _check(["node", "--version"], "Node.js"):
+        missing.append("Node.js")
+    if not _check(["git", "--version"], "Git"):
+        missing.append("Git")
+    if not _check(["docker", "--version"], "Docker"):
+        missing.append("Docker")
+
+    if missing:
+        raise RuntimeError(
+            "Dependencias faltantes: " + ", ".join(missing)
+        )
+
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,7 @@ def test_genesis_doctor(monkeypatch):
         return types.SimpleNamespace(returncode=0, stdout='tool version 1')
 
     monkeypatch.setattr(cmd_modules.doctor.subprocess, 'run', dummy_run)
+    monkeypatch.setattr(cmd_modules.utils.subprocess, 'run', dummy_run)
     import requests
     monkeypatch.setattr(requests, 'get', lambda *a, **kw: types.SimpleNamespace(status_code=200))
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,36 @@
+import importlib.util
+import types
+from pathlib import Path
+import sys
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+spec = importlib.util.spec_from_file_location(
+    'genesis_engine.cli.commands.utils',
+    ROOT / 'genesis_engine' / 'cli' / 'commands' / 'utils.py'
+)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+
+def test_check_dependencies_success(monkeypatch):
+    def dummy_run(*args, **kwargs):
+        return types.SimpleNamespace(returncode=0, stdout='v1')
+
+    monkeypatch.setattr(utils.subprocess, 'run', dummy_run)
+    monkeypatch.setattr(utils.sys, 'version_info', (3, 9, 0))
+    assert utils.check_dependencies() is True
+
+
+def test_check_dependencies_failure(monkeypatch):
+    def failing_run(cmd, *a, **kw):
+        if cmd[0] == 'docker':
+            raise FileNotFoundError
+        return types.SimpleNamespace(returncode=0, stdout='v1')
+
+    monkeypatch.setattr(utils.subprocess, 'run', failing_run)
+    monkeypatch.setattr(utils.sys, 'version_info', (3, 9, 0))
+
+    with pytest.raises(RuntimeError):
+        utils.check_dependencies()


### PR DESCRIPTION
## Summary
- add missing dependency verification in `check_dependencies`
- use `check_dependencies` inside the doctor command
- patch CLI tests to mock dependency checks
- add dedicated unit tests for dependency checking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2e9055188325a16b63faea8f29a9