### PR TITLE
Fix init command asyncio usage

### DIFF
--- a/cli
+++ b/cli
@@ -1,0 +1,1 @@
+genesis_engine/cli

--- a/genesis_engine/cli/commands/init.py
+++ b/genesis_engine/cli/commands/init.py
@@ -3,6 +3,7 @@ Genesis Init Command - Inicializar proyectos
 """
 
 import json
+import asyncio
 from pathlib import Path
 from typing import Optional
 from rich.console import Console
@@ -12,6 +13,10 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from genesis_engine.core.orchestrator import GenesisOrchestrator
 from genesis_engine.templates.engine import TemplateEngine
+import sys
+
+# Export real module reference for tests
+real_module = sys.modules[__name__]
 
 console = Console()
 
@@ -149,10 +154,12 @@ def init_command(
         }
 
         # Generar archivos usando template engine
-        template_engine.generate_project(
-            template_name=template,
-            output_dir=project_dir,
-            context=context
+        asyncio.run(
+            template_engine.generate_project(
+                template_name=template,
+                output_dir=project_dir,
+                context=context,
+            )
         )
         
         progress.update(task3, completed=1)

--- a/mcp
+++ b/mcp
@@ -1,0 +1,1 @@
+genesis_engine/mcp

--- a/templates
+++ b/templates
@@ -1,0 +1,1 @@
+genesis_engine/templates

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -69,7 +69,7 @@ class DummyOrchestratorForInit:
         return {"success": True, "result": {}}
 
 class DummyTemplateEngine:
-    def generate_project(self, template_name, output_dir, context):
+    async def generate_project(self, template_name, output_dir, context):
         return []
 
 def test_init_command_calls_design_architecture(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- make `genesis_engine.cli.commands.init` runnable with `asyncio.run`
- adjust orchestrator tests for async template engine
- provide package symlinks expected by tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b3aed54048325a97cfaa13751c124