### PR TITLE
Add explicit Genesis initialization

### DIFF
--- a/genesis_engine/cli/main.py
+++ b/genesis_engine/cli/main.py
@@ -18,6 +18,7 @@ from genesis_engine.cli.commands.deploy import deploy_command
 from genesis_engine.cli.commands.generate import generate_command
 from genesis_engine.cli.commands.utils import show_banner, check_dependencies
 from genesis_engine import __version__
+from genesis_engine.core.config import GenesisConfig
 
 # Configurar Rich Console
 
@@ -59,6 +60,7 @@ def main(
     Genesis Engine te permite crear, optimizar y desplegar aplicaciones
     completas usando agentes IA especializados que se comunican via MCP.
     """
+    GenesisConfig.initialize()
     if verbose:
         show_banner()
 

--- a/genesis_engine/core/config.py
+++ b/genesis_engine/core/config.py
@@ -292,6 +292,11 @@ class GenesisConfig:
             cache_dir.mkdir(parents=True, exist_ok=True)
             logging.info("Cache limpiado")
 
+    @classmethod
+    def initialize(cls):
+        """Inicializar Genesis Engine"""
+        initialize_genesis()
+
 # Funciones de utilidad
 def get_user_config_file() -> Path:
     """Obtener archivo de configuración del usuario"""
@@ -469,6 +474,3 @@ def validate_project_name(name: str) -> List[str]:
         errors.append(f"'{name}' es una palabra reservada")
     
     return errors
-
-# Inicializar al importar el módulo
-initialize_genesis()


### PR DESCRIPTION
## Summary
- add `GenesisConfig.initialize()` helper
- ensure CLI explicitly initializes Genesis before running commands
- drop automatic initialization on import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd8df64988325a83c95f0ad5ffd0c