### PR TITLE
Implement variable validation in template engine

### DIFF
--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -84,3 +84,27 @@ def test_generate_project_in_event_loop(tmp_path: Path):
     assert (out_dir / "sub" / "inner.txt").read_text() == "Inner World"
     assert (out_dir / "static.txt").read_text() == "STATIC"
 
+
+def test_missing_required_variables_render(tmp_path: Path):
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir(parents=True)
+    (templates_dir / "file.txt.j2").write_text("{{ project_name }} {{ description }}")
+
+    engine = TemplateEngine(templates_dir)
+
+    with pytest.raises(ValueError):
+        asyncio.run(engine.render_template("file.txt.j2", {"description": "test"}))
+
+
+def test_missing_required_variables_generate(tmp_path: Path):
+    templates_dir = tmp_path / "templates"
+    template_root = templates_dir / "sample"
+    template_root.mkdir(parents=True)
+    (template_root / "file.txt.j2").write_text("{{ project_name }} {{ description }}")
+
+    engine = TemplateEngine(templates_dir)
+    out_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError):
+        asyncio.run(engine.generate_project("sample", out_dir, {"project_name": "demo"}))
+


### PR DESCRIPTION
## Summary
- validate required variables in TemplateEngine using get_template_variables
- call validation from render_template and generate_project
- update get_template_variables to load source from loader
- test validation errors for missing project_name/description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd8e42d9c8325bca247b3221fe4d4