### PR TITLE
Make stack validation dynamic

### DIFF
--- a/genesis_engine/utils/validation.py
+++ b/genesis_engine/utils/validation.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass
 from enum import Enum
 from genesis_engine.core.logging import get_logger
+from genesis_engine.core.config import GenesisConfig
 import re
 
 class ValidationLevel(str, Enum):
@@ -540,23 +541,15 @@ class ConfigValidator:
         """Validar configuración del stack"""
         results = []
         
-        # Stacks válidos
-        valid_stacks = {
-            "backend": ["fastapi", "nestjs", "express", "django", "flask"],
-            "frontend": ["nextjs", "react", "vue", "nuxt", "svelte", "angular"],
-            "database": ["postgresql", "mysql", "mongodb", "sqlite"],
-            "styling": ["tailwind", "styled_components", "sass", "css_modules"],
-            "state_management": ["redux_toolkit", "zustand", "context_api", "pinia", "vuex"]
-        }
-        
         for key, value in stack.items():
-            if key in valid_stacks:
-                if value not in valid_stacks[key]:
+            valid_values = GenesisConfig.get_supported_frameworks(key)
+            if valid_values:
+                if value not in valid_values:
                     results.append(ValidationResult(
                         name=f"Stack: {key}",
                         level=ValidationLevel.ERROR,
                         message=f"Valor inválido para {key}: {value}",
-                        suggestion=f"Valores válidos: {', '.join(valid_stacks[key])}",
+                        suggestion=f"Valores válidos: {', '.join(valid_values)}",
                         passed=False
                     ))
                 else:

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from genesis_engine.core.config import GenesisConfig
+from genesis_engine.utils.validation import ConfigValidator, ValidationLevel
+
+
+def test_stack_validation_reflects_genesis_config():
+    validator = ConfigValidator()
+    test_config = {"name": "demo", "template": "saas-basic", "stack": {"backend": "laravel"}}
+
+    # Without modifying config, validation should fail for unknown framework
+    results = validator.validate_project_config(test_config)
+    assert any(r.name == "Stack: backend" and r.level == ValidationLevel.ERROR for r in results)
+
+    original = GenesisConfig.get_supported_frameworks("backend")
+    try:
+        # Add new framework and validate again
+        GenesisConfig.set("supported_frameworks.backend", original + ["laravel"])
+        results = validator.validate_project_config(test_config)
+        assert any(r.name == "Stack: backend" and r.level == ValidationLevel.SUCCESS for r in results)
+    finally:
+        GenesisConfig.set("supported_frameworks.backend", original)


### PR DESCRIPTION
## Summary
- pull supported frameworks from `GenesisConfig` inside `_validate_stack_config`
- add regression test to ensure config updates propagate to validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd8e6b86083259ac34f356b876195