### PR TITLE
Add cn utility for Next.js templates

### DIFF
--- a/genesis_engine/templates/frontend/nextjs/README.md
+++ b/genesis_engine/templates/frontend/nextjs/README.md
@@ -651,6 +651,17 @@ class ApiClient {
 export const apiClient = new ApiClient();
 ```
 
+## Template: nextjs/lib/utils.ts.j2
+
+```typescript
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
 ## Template: nextjs/components/ui/button.tsx.j2
 
 ```tsx

--- a/genesis_engine/templates/frontend/nextjs/lib/utils.ts.j2
+++ b/genesis_engine/templates/frontend/nextjs/lib/utils.ts.j2
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add `cn` helper for tailwind/clsx merging
- document `nextjs/lib/utils.ts.j2` in Next.js template README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd8e4aaa88325a5ff5cffc47b4999