### PR TITLE
Add typed hooks for Next.js template

### DIFF
--- a/genesis_engine/templates/frontend/nextjs/lib/hooks.ts.j2
+++ b/genesis_engine/templates/frontend/nextjs/lib/hooks.ts.j2
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from './store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
## Summary
- add `hooks.ts.j2` implementing typed Redux hooks

## Testing
- `pytest -q tests/test_agents_instantiation.py tests/test_architect_agent.py tests/test_backend_generation.py tests/test_cli.py tests/test_cli_deploy.py tests/test_cli_generate.py tests/test_cli_help.py tests/test_dependencies.py tests/test_devops_agent.py tests/test_environment_validator.py tests/test_logging_setup.py tests/test_orchestrator.py tests/test_template_engine.py tests/test_validation_config.py::test_stack_validation_reflects_genesis_config`

------
https://chatgpt.com/codex/tasks/task_e_686c0a7bb0688325b704e7c3c9f0591c