### PR TITLE
Fix GenesisConfig state leaks between tests

### DIFF
--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -21,10 +21,11 @@ GenesisConfig = config.GenesisConfig
 def test_setup_logging_idempotent(tmp_path):
     root_logger = logging.getLogger()
     original_handlers = list(root_logger.handlers)
+    cfg = GenesisConfig()
+    original_log_dir = cfg._config.get('log_dir')
     try:
         root_logger.handlers = []
 
-        cfg = GenesisConfig()
         cfg._config['log_dir'] = tmp_path
         cfg._setup_logging()
         cfg._setup_logging()
@@ -36,3 +37,4 @@ def test_setup_logging_idempotent(tmp_path):
         assert len(file_handlers) == 1
     finally:
         root_logger.handlers = original_handlers
+        cfg._config['log_dir'] = original_log_dir

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -4,8 +4,36 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from genesis_engine.core.config import GenesisConfig
-from genesis_engine.utils.validation import ConfigValidator, ValidationLevel
+import importlib.util
+import types
+
+# Build minimal genesis_engine package stubs
+genesis_pkg = sys.modules.setdefault('genesis_engine', types.ModuleType('genesis_engine'))
+genesis_pkg.__path__ = [str(ROOT), str(ROOT / 'genesis_engine')]
+core_pkg = sys.modules.setdefault('genesis_engine.core', types.ModuleType('genesis_engine.core'))
+core_pkg.__path__ = [str(ROOT / 'genesis_engine' / 'core')]
+utils_pkg = sys.modules.setdefault('genesis_engine.utils', types.ModuleType('genesis_engine.utils'))
+utils_pkg.__path__ = [str(ROOT / 'genesis_engine' / 'utils')]
+
+spec_cfg = importlib.util.spec_from_file_location(
+    'genesis_engine.core.config',
+    ROOT / 'genesis_engine' / 'core' / 'config.py'
+)
+cfg_mod = importlib.util.module_from_spec(spec_cfg)
+sys.modules['genesis_engine.core.config'] = cfg_mod
+spec_cfg.loader.exec_module(cfg_mod)
+
+spec_val = importlib.util.spec_from_file_location(
+    'genesis_engine.utils.validation',
+    ROOT / 'genesis_engine' / 'utils' / 'validation.py'
+)
+val_mod = importlib.util.module_from_spec(spec_val)
+sys.modules['genesis_engine.utils.validation'] = val_mod
+spec_val.loader.exec_module(val_mod)
+
+GenesisConfig = cfg_mod.GenesisConfig
+ConfigValidator = val_mod.ConfigValidator
+ValidationLevel = val_mod.ValidationLevel
 
 
 def test_stack_validation_reflects_genesis_config():


### PR DESCRIPTION
## Summary
- ensure `test_setup_logging_idempotent` resets the log_dir change
- reload core and validation modules in `test_validation_config` to use a fresh `GenesisConfig`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c0a7bd5e883259cc9852e23d6649b