### PR TITLE
Add React support to FrontendAgent

### DIFF
--- a/genesis_engine/agents/ai_ready.py
+++ b/genesis_engine/agents/ai_ready.py
@@ -662,4 +662,5 @@ TEMPERATURE={config.temperature}
         return ""
     
     async def _generate_chat_page(self, frontend_path: Path, config: AIConfig) -> str:
-        """Generar página de chat"""        return ""
+        """Generar página de chat"""
+        return ""

--- a/genesis_engine/agents/frontend.py
+++ b/genesis_engine/agents/frontend.py
@@ -1,12 +1,10 @@
-"""
-Template Engine - Motor de plantillas Jinja2 para Genesis Engine
+"""Frontend Agent
+-----------------
 
-Este módulo es responsable de:
-- Cargar y renderizar plantillas Jinja2
-- Gestionar templates modulares por tecnología
-- Proporcionar funciones helper personalizadas
-- Validar sintaxis y variables de templates
-- Cache de templates para mejor performance
+Agent responsible for generating frontend projects using different
+JavaScript frameworks. It leverages the :class:`TemplateEngine` to
+render Jinja2 templates and produce a ready to use project skeleton.
+Currently Next.js and React templates are bundled with the engine.
 """
 
 import os
@@ -27,7 +25,7 @@ template_engine = TemplateEngine()
 
 
 class FrontendAgent(GenesisAgent):
-    """Agente Frontend - Generador de interfaz Next.js"""
+    """Agente Frontend - Generador de interfaces web"""
 
     def __init__(self):
         super().__init__(
@@ -38,6 +36,7 @@ class FrontendAgent(GenesisAgent):
 
         # Capacidades básicas
         self.add_capability("nextjs_generation")
+        self.add_capability("react_generation")
         self.add_capability("ui_components")
         self.add_capability("state_management")
 
@@ -50,7 +49,7 @@ class FrontendAgent(GenesisAgent):
         self.logger.info("🎨 Inicializando Frontend Agent")
 
         self.set_metadata("version", "1.0.0")
-        self.set_metadata("supported_frameworks", ["nextjs"])
+        self.set_metadata("supported_frameworks", ["nextjs", "react"])
 
         self.logger.info("✅ Frontend Agent inicializado")
 
@@ -68,8 +67,12 @@ class FrontendAgent(GenesisAgent):
         return await self._generate_complete_frontend(request.params)
 
     async def _generate_complete_frontend(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Generar proyecto Next.js básico"""
-        self.logger.info("🚀 Generando frontend Next.js")
+        """Generate a frontend project for the selected framework."""
+        framework = params.get("framework", "nextjs").lower()
+        if framework not in {"nextjs", "react"}:
+            raise ValueError(f"Framework no soportado: {framework}")
+
+        self.logger.info(f"🚀 Generando frontend {framework}")
 
         schema = params.get("schema", {})
         output_path = Path(params.get("output_path", "./frontend"))
@@ -84,13 +87,14 @@ class FrontendAgent(GenesisAgent):
             "ui_components": params.get("ui_components", "shadcn"),
         }
 
+        template_glob = f"frontend/{framework}/*"
         templates = [
-            t for t in self.template_engine.list_templates("frontend/nextjs/*")
+            t for t in self.template_engine.list_templates(template_glob)
             if t.endswith(".j2")
         ]
 
         generated_files: List[str] = []
-        prefix = "frontend/nextjs/"
+        prefix = f"frontend/{framework}/"
 
         for tpl in templates:
             content = await self.template_engine.render_template(tpl, template_vars)
@@ -102,7 +106,7 @@ class FrontendAgent(GenesisAgent):
             generated_files.append(str(out_file))
 
         return {
-            "framework": "nextjs",
+            "framework": framework,
             "generated_files": generated_files,
             "output_path": str(output_path),
             "next_steps": [

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -51,6 +51,13 @@ class TemplateEngine:
             "styling",
             "state_management",
         ],
+        "frontend/react/*": [
+            "project_name",
+            "description",
+            "typescript",
+            "styling",
+            "state_management",
+        ],
         "saas-basic/*": [
             "project_name",
             "description",

--- a/genesis_engine/templates/frontend/react/index.html.j2
+++ b/genesis_engine/templates/frontend/react/index.html.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ project_name }}</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/genesis_engine/templates/frontend/react/package.json.j2
+++ b/genesis_engine/templates/frontend/react/package.json.j2
@@ -1,0 +1,15 @@
+{
+  "name": "{{ project_name|kebab_case }}",
+  "version": "0.1.0",
+  "private": true,
+  "description": "{{ description }}",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/genesis_engine/templates/frontend/react/src/App.tsx.j2
+++ b/genesis_engine/templates/frontend/react/src/App.tsx.j2
@@ -1,0 +1,8 @@
+export default function App() {
+  return (
+    <div>
+      <h1>{{ project_name }}</h1>
+      <p>{{ description }}</p>
+    </div>
+  );
+}

--- a/genesis_engine/templates/frontend/react/src/main.tsx.j2
+++ b/genesis_engine/templates/frontend/react/src/main.tsx.j2
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tests/test_frontend_generation.py
+++ b/tests/test_frontend_generation.py
@@ -1,0 +1,37 @@
+import asyncio
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from genesis_engine.agents.frontend import FrontendAgent
+from genesis_engine.templates.engine import TemplateEngine
+
+async def run_async(coro):
+    return await coro
+
+
+def make_agent():
+    agent = FrontendAgent()
+    agent.template_engine = TemplateEngine(ROOT / 'genesis_engine' / 'templates')
+    return agent
+
+
+def test_generate_react_frontend(tmp_path):
+    agent = make_agent()
+    schema = {"project_name": "DemoApp", "description": "Demo"}
+    params = {"schema": schema, "framework": "react", "output_path": tmp_path}
+    result = asyncio.run(agent._generate_complete_frontend(params))
+
+    expected = {
+        tmp_path / "package.json",
+        tmp_path / "index.html",
+        tmp_path / "src" / "App.tsx",
+        tmp_path / "src" / "main.tsx",
+    }
+
+    assert set(map(Path, result["generated_files"])) == expected
+    assert result["framework"] == "react"
+    assert "DemoApp" in (tmp_path / "src" / "App.tsx").read_text()
+


### PR DESCRIPTION
## Summary
- describe FrontendAgent in module docstring
- support React templates and metadata
- update template engine required vars
- add minimal React templates
- add tests for React frontend generation
- fix syntax in ai_ready agent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d7a0c2de88325b12b5bd445e947a3