### PR TITLE
Add configurable template variable validation

### DIFF
--- a/genesis_engine/core/config.py
+++ b/genesis_engine/core/config.py
@@ -100,6 +100,7 @@ class GenesisConfig:
             "max_workers": 4,
             "timeout": 300,
             "retry_attempts": 3,
+            "strict_template_validation": True,
             "stack_defaults": {
                 "golden-path": StackDefaults.GOLDEN_PATH,
                 "api-first": StackDefaults.API_FIRST,

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional, Union
 import fnmatch
 from datetime import datetime
 from genesis_engine.core.logging import get_logger
+from genesis_engine.core.config import GenesisConfig
 
 from jinja2 import Environment, FileSystemLoader, Template, TemplateError
 from jinja2.exceptions import TemplateNotFound, TemplateSyntaxError
@@ -57,8 +58,11 @@ class TemplateEngine:
         ],
     }
     
-    def __init__(self, templates_dir: Optional[Path] = None):
+    def __init__(self, templates_dir: Optional[Path] = None, strict_validation: Optional[bool] = None):
         self.templates_dir = templates_dir or self._get_default_templates_dir()
+        if strict_validation is None:
+            strict_validation = GenesisConfig.get("strict_template_validation", True)
+        self.strict_validation = strict_validation
         self.env = self._setup_jinja_environment()
         self.logger = get_logger("genesis.template_engine")
         
@@ -175,9 +179,13 @@ class TemplateEngine:
                     if name not in variables:
                         missing.add(name)
         if missing:
-            raise KeyError(
-                f"Variables faltantes para {template_name}: {', '.join(sorted(missing))}"
-            )
+            message = f"Variables faltantes para {template_name}: {', '.join(sorted(missing))}"
+            if self.strict_validation:
+                raise KeyError(message)
+            else:
+                self.logger.warning(message)
+                for name in missing:
+                    variables.setdefault(name, "")
     
     async def render_template(
         self,

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -90,16 +90,20 @@ def test_missing_required_vars(tmp_path: Path):
     templates_dir.mkdir(parents=True, exist_ok=True)
     (templates_dir / "file.j2").write_text("{{ project_name }}")
 
-    engine = TemplateEngine(templates_dir)
+    engine_strict = TemplateEngine(templates_dir, strict_validation=True)
+    engine_lenient = TemplateEngine(templates_dir, strict_validation=False)
 
     original = TemplateEngine.REQUIRED_VARIABLES.copy()
     TemplateEngine.REQUIRED_VARIABLES["file.j2"] = ["project_name"]
 
     try:
         with pytest.raises(KeyError):
-            asyncio.run(engine.render_template("file.j2", {}))
+            asyncio.run(engine_strict.render_template("file.j2", {}))
 
-        result = asyncio.run(engine.render_template("file.j2", {"project_name": "Demo"}))
+        result = asyncio.run(engine_lenient.render_template("file.j2", {}))
+        assert result == ""
+
+        result = asyncio.run(engine_lenient.render_template("file.j2", {"project_name": "Demo"}))
         assert result == "Demo"
     finally:
         TemplateEngine.REQUIRED_VARIABLES.clear()


### PR DESCRIPTION
## Summary
- allow TemplateEngine to warn or default missing variables instead of failing
- make strict validation configurable via `GenesisConfig`
- adjust template engine tests for new behavior

## Testing
- `pytest -q tests/test_template_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_686d7a0ef0a88325a5b443080f51494e