### PR TITLE
Fix render_vars initialization in async template rendering

### DIFF
--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -233,6 +233,7 @@ class TemplateEngine:
     ) -> str:
         """Renderizar una plantilla de forma asíncrona."""
         vars_clean = variables or {}
+        render_vars = vars_clean
         # Validar variables antes de ejecutar en hilo separado
         self.validate_required_variables(template_name, vars_clean)
         try:


### PR DESCRIPTION
## Summary
- fix undefined variable `render_vars` in `render_template` async method

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ImportError in tests due to SyntaxError in backend.py)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d25c6708325bf8c288562f99aa8