### PR TITLE
Fix async generation functions

### DIFF
--- a/genesis_engine/agents/backend.py
+++ b/genesis_engine/agents/backend.py
@@ -222,11 +222,15 @@ class BackendAgent(GenesisAgent):
         generated_files.extend(config_files)
         
         # 7. Documentación
-        doc_files = self._generate_api_documentation({
-            "schema": project_schema,
-            "config": config,
-            "output_path": output_path / "docs"
-        })
+        doc_files = asyncio.run(
+            self._generate_api_documentation(
+                {
+                    "schema": project_schema,
+                    "config": config,
+                    "output_path": output_path / "docs",
+                }
+            )
+        )
         generated_files.extend(doc_files)
         
         result = {
@@ -575,14 +579,18 @@ class BackendAgent(GenesisAgent):
         output_path = Path(params.get("output_path", "./auth"))
         
         generated_files = []
-        
+
         if config.auth_method == AuthMethod.JWT:
             if config.framework == BackendFramework.FASTAPI:
-                auth_files = self._generate_fastapi_jwt_auth(output_path, config)
+                auth_files = asyncio.run(
+                    self._generate_fastapi_jwt_auth(output_path, config)
+                )
                 generated_files.extend(auth_files)
-                
+
             elif config.framework == BackendFramework.NESTJS:
-                auth_files = self._generate_nestjs_jwt_auth(output_path, config)
+                auth_files = asyncio.run(
+                    self._generate_nestjs_jwt_auth(output_path, config)
+                )
                 generated_files.extend(auth_files)
         
         self.logger.info(f"✅ Autenticación configurada - {len(generated_files)} archivos")
@@ -696,7 +704,7 @@ class BackendAgent(GenesisAgent):
     
     def _handle_generate_docs(self, request) -> Dict[str, Any]:
         """Handler para generación de docs"""
-        files = self._generate_api_documentation(request.params)
+        files = asyncio.run(self._generate_api_documentation(request.params))
         return {"generated_files": files}
     
     # Métodos auxiliares que se implementarían completamente
@@ -858,7 +866,7 @@ class BackendAgent(GenesisAgent):
 
         return str(output_file)
     
-    def _generate_fastapi_jwt_auth(self, output_path: Path, config: BackendConfig) -> List[str]:
+    async def _generate_fastapi_jwt_auth(self, output_path: Path, config: BackendConfig) -> List[str]:
         """Generar autenticación JWT para FastAPI"""
         output_path.mkdir(parents=True, exist_ok=True)
 
@@ -878,7 +886,7 @@ class BackendAgent(GenesisAgent):
 
         return [str(auth_file)]
     
-    def _generate_nestjs_jwt_auth(self, output_path: Path, config: BackendConfig) -> List[str]:
+    async def _generate_nestjs_jwt_auth(self, output_path: Path, config: BackendConfig) -> List[str]:
         """Generar autenticación JWT para NestJS"""
         output_path.mkdir(parents=True, exist_ok=True)
 
@@ -952,7 +960,7 @@ class BackendAgent(GenesisAgent):
 
         return str(output_file)
     
-    def _generate_api_documentation(self, params: Dict[str, Any]) -> List[str]:
+    async def _generate_api_documentation(self, params: Dict[str, Any]) -> List[str]:
         """Generar documentación de API"""
         output_path = Path(params.get("output_path", "./docs"))
         output_path.mkdir(parents=True, exist_ok=True)

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -200,11 +200,13 @@ class TemplateEngine:
 
         self,
         template_name: str,
-        variables: Dict[str, Any],
-        use_cache: bool,
+        variables: Dict[str, Any] | None = None,
+        use_cache: bool = True,
     ) -> str:
         """Versión síncrona del renderizado de plantillas."""
-        render_vars = variables or {}
+        vars_clean = variables or {}
+        self.validate_required_variables(template_name, vars_clean)
+        render_vars = vars_clean
 
         # Obtener template (con cache si está habilitado)
         if use_cache and template_name in self._template_cache:
@@ -225,7 +227,7 @@ class TemplateEngine:
 
         return template.render(**render_vars)
 
-    async def render_template(
+    async def render_template_async(
         self,
         template_name: str,
         variables: Dict[str, Any] = None,
@@ -286,7 +288,7 @@ class TemplateEngine:
         )
         return template.render(**render_vars)
 
-    async def render_string_template(
+    async def render_string_template_async(
         self,
         template_string: str,
         variables: Dict[str, Any] = None,
@@ -296,7 +298,7 @@ class TemplateEngine:
         self.validate_required_variables("string_template", vars_clean)
         try:
             return await asyncio.to_thread(
-                self._render_string_template_sync, template_string, vars_clean
+                self.render_string_template, template_string, vars_clean
             )
         except Exception as e:
             self.logger.error(f"❌ Error renderizando string template: {e}")
@@ -434,7 +436,7 @@ class TemplateEngine:
 
         return generated_files
 
-    async def generate_project(
+    async def generate_project_async(
         self,
         template_name: str,
         output_dir: Union[str, Path],
@@ -442,7 +444,7 @@ class TemplateEngine:
     ) -> List[str]:
         """Renderizar todas las plantillas dentro de un directorio de forma asíncrona"""
         return await asyncio.to_thread(
-            self._generate_project_sync, template_name, output_dir, context
+            self.generate_project, template_name, output_dir, context
         )
     
     def register_helper(self, name: str, func: callable):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,8 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
 import yaml
 import genesis_engine

--- a/tests/test_backend_generation.py
+++ b/tests/test_backend_generation.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import asyncio
 
 import sys
 
@@ -105,7 +106,7 @@ def test_setup_authentication(tmp_path, monkeypatch):
         environment_vars={},
     )
 
-    def fake_generate_fastapi_jwt_auth(path, cfg):
+    async def fake_generate_fastapi_jwt_auth(path, cfg):
         path.mkdir(parents=True, exist_ok=True)
         file = path / 'jwt.py'
         file.write_text('auth')
@@ -184,7 +185,7 @@ def test_generate_fastapi_jwt_auth(tmp_path):
         dependencies=[],
         environment_vars={},
     )
-    paths = agent._generate_fastapi_jwt_auth(tmp_path, config)
+    paths = asyncio.run(agent._generate_fastapi_jwt_auth(tmp_path, config))
     file = tmp_path / 'jwt.py'
     assert list(map(Path, paths)) == [file]
     assert 'SECRET_KEY' in file.read_text()
@@ -200,7 +201,7 @@ def test_generate_nestjs_jwt_auth(tmp_path):
         dependencies=[],
         environment_vars={},
     )
-    paths = agent._generate_nestjs_jwt_auth(tmp_path, config)
+    paths = asyncio.run(agent._generate_nestjs_jwt_auth(tmp_path, config))
     file = tmp_path / 'jwt.ts'
     assert list(map(Path, paths)) == [file]
     assert 'jwtConstants' in file.read_text()
@@ -233,7 +234,7 @@ def test_generate_api_documentation(tmp_path):
         environment_vars={},
     )
     params = {'schema': {}, 'config': config, 'output_path': tmp_path}
-    paths = agent._generate_api_documentation(params)
+    paths = asyncio.run(agent._generate_api_documentation(params))
     file = tmp_path / 'api.md'
     assert list(map(Path, paths)) == [file]
     assert 'API Documentation' in file.read_text()


### PR DESCRIPTION
## Summary
- make `_generate_fastapi_jwt_auth`, `_generate_nestjs_jwt_auth` and `_generate_api_documentation` async
- run these async functions using `asyncio.run`
- ensure repo packages are imported instead of installed version for tests
- expose async helpers in `TemplateEngine` without overriding sync APIs
- update tests for async calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6d2539a0832589062fd2d894ebbd