### PR TITLE
Fix async project generation

### DIFF
--- a/genesis_engine/__init__.py
+++ b/genesis_engine/__init__.py
@@ -22,7 +22,7 @@ try:
     from genesis_engine.core.project_manager import ProjectManager
     from genesis_engine.mcp.protocol import MCPProtocol
     from genesis_engine.mcp.agent_base import GenesisAgent
-except ImportError as e:  # pragma: no cover - graceful fallback if deps fail
+except Exception as e:  # pragma: no cover - graceful fallback if deps fail
     logger.error(f"Failed to import core dependencies: {e}", exc_info=True)
     GenesisOrchestrator = None
     ProjectManager = None
@@ -36,5 +36,4 @@ __all__ = [
     "GenesisAgent",
     "__version__",
     "__author__",
-    "__email__"
-]
+    "__email__"]

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -394,16 +394,19 @@ class TemplateEngine:
             return []
 
 
-    def generate_project(
+    def _generate_project_sync(
 
         self,
         template_name: str,
         output_dir: Union[str, Path],
-        context: Optional[Dict[str, Any]],
+        context: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
+        """Lógica interna para generar un proyecto de forma síncrona."""
         template_path = self.templates_dir / template_name
         if not template_path.exists() or not template_path.is_dir():
-            raise FileNotFoundError(f"Directorio de template no encontrado: {template_path}")
+            raise FileNotFoundError(
+                f"Directorio de template no encontrado: {template_path}"
+            )
 
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
@@ -434,7 +437,17 @@ class TemplateEngine:
 
         return generated_files
 
-    async def generate_project(
+    def generate_project(
+
+        self,
+        template_name: str,
+        output_dir: Union[str, Path],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> List[str]:
+        """Generar todas las plantillas dentro de un directorio de forma síncrona."""
+        return self._generate_project_sync(template_name, output_dir, context)
+
+    async def generate_project_async(
         self,
         template_name: str,
         output_dir: Union[str, Path],


### PR DESCRIPTION
## Summary
- refactor project generation logic into `_generate_project_sync`
- provide synchronous `generate_project` wrapper and `generate_project_async`
- relax import error handling in `__init__`

## Testing
- `pytest -q` *(fails: SyntaxError in backend.py)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d26c0ec8325a2af5bdc3f713bfb