### PR TITLE
Fix duplicate get_capabilities definition

### DIFF
--- a/genesis_engine/mcp/agent_base.py
+++ b/genesis_engine/mcp/agent_base.py
@@ -61,8 +61,6 @@ class GenesisAgent(BaseAgent):
     def get_metadata(self, key: str, default: Any = None) -> Any:
         return self.metadata.get(key, default)
 
-    def get_capabilities(self) -> list:
-        return list(self.capabilities)
 
     async def handle_request(self, request: MCPRequest) -> Dict[str, Any]:
 


### PR DESCRIPTION
## Summary
- remove the extra `get_capabilities` method in `GenesisAgent`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e933e4fec8325822a6a1274b1639d