### PR TITLE
Fix dependency lists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,20 @@ dependencies = [
     "sqlalchemy>=2.0.23",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "kubernetes==28.1.0",
+    "alembic==1.13.1",
+    "psycopg2-binary==2.9.9",
+    "redis==5.0.1",
+    "celery==5.3.4",
+    "pytest==7.4.3",
+    "pytest-asyncio==0.21.1",
+    "black==23.11.0",
+    "isort==5.12.0",
+    "mypy==1.7.1",
+]
+
 [project.urls]
 Homepage = "https://github.com/genesis-engine/genesis-engine"
 Documentation = "https://docs.genesis-engine.dev"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ pytest-asyncio==0.21.1
 black==23.11.0
 isort==5.12.0
 mypy==1.7.1
-rich>=13.7.0


### PR DESCRIPTION
## Summary
- dedupe `rich` in requirements
- keep optional packages like `kubernetes` under `[project.optional-dependencies]`

## Testing
- `pytest -q` *(fails: AttributeError in CLI tests, TypeError in template engine tests)*

------
https://chatgpt.com/codex/tasks/task_e_686e933fa45c8325b9b433bec8ad45f3