### PR TITLE
Fix event loop detection

### DIFF
--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -432,6 +432,11 @@ class TemplateEngine:
         context: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         """Lógica interna para generar un proyecto de forma síncrona."""
+        try:
+            asyncio.get_running_loop()
+            in_event_loop = True
+        except RuntimeError:
+            in_event_loop = False
         template_path = self.templates_dir / template_name
         if not template_path.exists() or not template_path.is_dir():
             raise FileNotFoundError(


### PR DESCRIPTION
## Summary
- detect if generate_project is already running inside an event loop

## Testing
- `pytest -q` *(fails: AttributeError: module 'genesis_engine.cli.commands' has no attribute 'doctor')*

------
https://chatgpt.com/codex/tasks/task_e_686e933fdb108325a80aca760a4bc0e1