### PR TITLE
Add pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+pythonpath = .


### PR DESCRIPTION
## Summary
- provide pytest.ini so tests can import `genesis_engine`

## Testing
- `pytest -q` *(fails: ImportError from genesis_engine.core.logging)*

------
https://chatgpt.com/codex/tasks/task_e_686ec202bcd48325915e8b48c825af04