### PR TITLE
Convert tests to async functions

### DIFF
--- a/tests/test_agent_base_async.py
+++ b/tests/test_agent_base_async.py
@@ -1,20 +1,22 @@
 import asyncio
 import sys
 from pathlib import Path
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from genesis_engine.mcp.agent_base import GenesisAgent
+from genesis_engine.mcp.agent_base import create_simple_agent
 from genesis_engine.mcp.message_types import MCPRequest
 
 
-def test_async_handler_runs_in_running_loop():
-    agent = GenesisAgent(agent_id="a1", name="Agent", agent_type="test")
+@pytest.mark.asyncio
+async def test_async_handler_runs_in_running_loop():
+    agent = create_simple_agent("a1", "Agent")
 
-    async def handler(data):
+    async def handler(request):
         await asyncio.sleep(0)
-        return data["x"]
+        return request.data["x"]
 
     agent.register_handler("act", handler)
     req = MCPRequest(
@@ -25,9 +27,6 @@ def test_async_handler_runs_in_running_loop():
         timeout=1,
     )
 
-    async def run():
-        result = await agent.handle_request(req)
-        assert result == 123
-
-    asyncio.run(run())
+    result = await agent.handle_request(req)
+    assert result == 123
 

--- a/tests/test_deploy_cloud.py
+++ b/tests/test_deploy_cloud.py
@@ -1,6 +1,6 @@
-import asyncio
 import sys
 from pathlib import Path
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -14,7 +14,8 @@ from genesis_engine.agents.deploy import (
 )
 
 
-def test_deploy_to_heroku(monkeypatch, tmp_path):
+@pytest.mark.asyncio
+async def test_deploy_to_heroku(monkeypatch, tmp_path):
     agent = DeployAgent()
     calls = []
 
@@ -24,14 +25,15 @@ def test_deploy_to_heroku(monkeypatch, tmp_path):
 
     monkeypatch.setattr(agent, "_run_command", dummy)
     config = DeploymentConfig(target=DeploymentTarget.HEROKU, environment=DeploymentEnvironment.DEVELOPMENT, custom_config={"app_name": "demo"})
-    result = asyncio.run(agent._deploy_to_heroku(tmp_path, config))
+    result = await agent._deploy_to_heroku(tmp_path, config)
 
     assert result.success
     assert result.target == DeploymentTarget.HEROKU
     assert calls
 
 
-def test_deploy_to_vercel(monkeypatch, tmp_path):
+@pytest.mark.asyncio
+async def test_deploy_to_vercel(monkeypatch, tmp_path):
     agent = DeployAgent()
     calls = []
 
@@ -41,14 +43,15 @@ def test_deploy_to_vercel(monkeypatch, tmp_path):
 
     monkeypatch.setattr(agent, "_run_command", dummy)
     config = DeploymentConfig(target=DeploymentTarget.VERCEL, environment=DeploymentEnvironment.DEVELOPMENT)
-    result = asyncio.run(agent._deploy_to_vercel(tmp_path, config))
+    result = await agent._deploy_to_vercel(tmp_path, config)
 
     assert result.success
     assert result.target == DeploymentTarget.VERCEL
     assert calls
 
 
-def test_deploy_to_aws(monkeypatch, tmp_path):
+@pytest.mark.asyncio
+async def test_deploy_to_aws(monkeypatch, tmp_path):
     agent = DeployAgent()
     (tmp_path / "file.txt").write_text("data")
     calls = []
@@ -66,7 +69,7 @@ def test_deploy_to_aws(monkeypatch, tmp_path):
     monkeypatch.setattr(deploy_mod.shutil, "make_archive", fake_make_archive)
 
     config = DeploymentConfig(target=DeploymentTarget.AWS, environment=DeploymentEnvironment.DEVELOPMENT, custom_config={"app_name": "demo", "bucket": "bkt"})
-    result = asyncio.run(agent._deploy_to_aws(tmp_path, config))
+    result = await agent._deploy_to_aws(tmp_path, config)
 
     assert result.success
     assert result.target == DeploymentTarget.AWS

--- a/tests/test_performance_agent.py
+++ b/tests/test_performance_agent.py
@@ -1,25 +1,23 @@
-import asyncio
 from pathlib import Path
 import sys
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from genesis_engine.agents.performance import PerformanceAgent
 
-async def run_async(coro):
-    return await coro
-
 
 def make_agent():
     return PerformanceAgent()
 
 
-def test_security_audit_detects_issues(tmp_path):
+@pytest.mark.asyncio
+async def test_security_audit_detects_issues(tmp_path):
     file = tmp_path / "main.py"
     file.write_text("password = '123'\nprint(eval('1+1'))\n")
     agent = make_agent()
-    result = asyncio.run(agent._perform_security_audit({"project_path": tmp_path}))
+    result = await agent._perform_security_audit({"project_path": tmp_path})
     assert result["issues"]
     assert result["files_modified"] == [str(file)]
     report = Path(result["report_file"])
@@ -27,28 +25,31 @@ def test_security_audit_detects_issues(tmp_path):
     assert "# TODO" in file.read_text()
 
 
-def test_optimize_database_queries(tmp_path):
+@pytest.mark.asyncio
+async def test_optimize_database_queries(tmp_path):
     file = tmp_path / "db.py"
     file.write_text("db.execute('SELECT * FROM users')\nfor u in User.objects.all():\n    pass\n")
     agent = make_agent()
-    result = asyncio.run(agent._optimize_database_queries({"project_path": tmp_path}))
+    result = await agent._optimize_database_queries({"project_path": tmp_path})
     assert result["optimizations"]
     assert result["files_modified"] == [str(file)]
     assert "# TODO" in file.read_text()
 
 
-def test_setup_caching_creates_config(tmp_path):
+@pytest.mark.asyncio
+async def test_setup_caching_creates_config(tmp_path):
     agent = make_agent()
-    result = asyncio.run(agent._setup_caching_strategy({"project_path": tmp_path}))
+    result = await agent._setup_caching_strategy({"project_path": tmp_path})
     config = tmp_path / "cache_config.json"
     assert result["optimizations"]
     assert result["files_modified"] == [str(config)]
     assert config.exists()
 
 
-def test_setup_monitoring_creates_config(tmp_path):
+@pytest.mark.asyncio
+async def test_setup_monitoring_creates_config(tmp_path):
     agent = make_agent()
-    result = asyncio.run(agent._setup_performance_monitoring({"project_path": tmp_path}))
+    result = await agent._setup_performance_monitoring({"project_path": tmp_path})
     config = tmp_path / ".genesis" / "monitoring.json"
     assert result["optimizations"]
     assert result["files_modified"] == [str(config)]


### PR DESCRIPTION
## Summary
- convert selected tests to use `async def` with `pytest.mark.asyncio`
- call async methods with `await` instead of `asyncio.run`

## Testing
- `pytest -q tests/test_agent_base_async.py tests/test_performance_agent.py tests/test_deploy_cloud.py`

------
https://chatgpt.com/codex/tasks/task_e_686ec204d8d883259d16fb95dedea452