### PR TITLE
Implement initialize helper for config

### DIFF
--- a/genesis_engine/cli/main.py
+++ b/genesis_engine/cli/main.py
@@ -20,7 +20,7 @@ from concurrent.futures import ThreadPoolExecutor
 # Importar componentes core
 from genesis_engine.core.exceptions import GenesisException, ProjectCreationError
 from genesis_engine.core.orchestrator import GenesisOrchestrator
-from genesis_engine.core.config import GenesisConfig
+from genesis_engine.core.config import initialize
 from genesis_engine.core.logging import get_logger
 from genesis_engine import __version__
 
@@ -144,7 +144,7 @@ def main(
         
     # Inicializar configuración
     try:
-        GenesisConfig.initialize()
+        initialize()
         if verbose:
             logger.info("Configuración inicializada en modo verbose")
     except Exception as e:
@@ -349,7 +349,7 @@ def doctor():
         # Verificar configuración
         console.print("\n[bold cyan]⚙️ Verificando configuración...[/bold cyan]")
         try:
-            GenesisConfig.initialize()
+            initialize()
             console.print("[green]✅ Configuración OK[/green]")
         except Exception as e:
             console.print(f"[red]❌ Error en configuración: {e}[/red]")

--- a/genesis_engine/core/config.py
+++ b/genesis_engine/core/config.py
@@ -307,7 +307,33 @@ def load_user_config(config_file: Optional[Union[str, Path]] = None) -> GenesisC
     config = GenesisConfig.from_file(config_file)
     set_config(config)
     configure_environment()
-    
+
+    return config
+
+def initialize(
+    config_file: Optional[Union[str, Path]] = None,
+    level: Optional[str] = None,
+    log_file: Optional[Union[str, Path]] = None,
+    enable_rich: Optional[bool] = None,
+) -> GenesisConfig:
+    """Inicializar configuración global y logging.
+
+    Esta función carga la configuración de usuario y establece el entorno y
+    el sistema de logging de Genesis Engine.
+
+    Args:
+        config_file: Ruta alternativa al archivo de configuración de usuario.
+        level: Nivel de logging a utilizar.
+        log_file: Archivo de log a emplear.
+        enable_rich: Habilitar salida enriquecida mediante Rich.
+
+    Returns:
+        Instancia de :class:`GenesisConfig` cargada.
+    """
+
+    config = load_user_config(config_file)
+    setup_logging(level=level, log_file=log_file, enable_rich=enable_rich)
+    configure_environment()
     return config
 
 def save_user_config(config: Optional[GenesisConfig] = None, config_file: Optional[Union[str, Path]] = None):
@@ -327,5 +353,4 @@ def save_user_config(config: Optional[GenesisConfig] = None, config_file: Option
     config.save_to_file(config_file)
 
 # Configuración por defecto al importar el módulo
-if _config_instance is None:
-    _config_instance = load_user_config()
+if _config_instance is None:    _config_instance = load_user_config()

--- a/genesis_engine/core/logging.py
+++ b/genesis_engine/core/logging.py
@@ -1,4 +1,3 @@
-from genesis_engine.core.logging import get_logger
 import logging
 from pathlib import Path
 from typing import Optional


### PR DESCRIPTION
## Summary
- add an `initialize` helper in `core.config`
- update CLI to use the helper instead of the old class method
- clean up logging module circular import

## Testing
- `pytest -q` *(fails: AttributeError: type object 'GenesisConfig' has no attribute 'get')*

------
https://chatgpt.com/codex/tasks/task_e_686ec269e7a0832598bd1f3d9c646428