### PR TITLE
Add metadata helpers to GenesisAgent

### DIFF
--- a/genesis_engine/mcp/agent_base.py
+++ b/genesis_engine/mcp/agent_base.py
@@ -90,6 +90,7 @@ class GenesisAgent(ABC):
         self.handlers: Dict[str, Callable] = {}
         self.version = "1.0.0"
         self.logger = logging.getLogger(f"agent.{self.agent_id}")
+        self.metadata: Dict[str, Any] = {}
         
         # Registrar handlers básicos requeridos por MCP
         self._register_core_handlers()
@@ -274,17 +275,25 @@ class GenesisAgent(ABC):
         if capability not in self.capabilities:
             self.capabilities.append(capability)
             self.logger.debug(f"Capacidad agregada: {capability}")
-    
+
     def remove_capability(self, capability: str):
         """Remover capacidad del agente"""
         if capability in self.capabilities:
             self.capabilities.remove(capability)
             self.logger.debug(f"Capacidad removida: {capability}")
-    
+
     def has_capability(self, capability: str) -> bool:
         """Verificar si el agente tiene una capacidad específica"""
         return capability in self.capabilities
-    
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        """Establecer un valor en la metadata del agente"""
+        self.metadata[key] = value
+
+    def get_metadata(self, key: str, default: Any = None) -> Any:
+        """Obtener un valor de la metadata del agente"""
+        return self.metadata.get(key, default)
+
     def get_info(self) -> Dict[str, Any]:
         """Obtener información completa del agente"""
         return {
@@ -294,7 +303,8 @@ class GenesisAgent(ABC):
             "status": self.status,
             "version": self.version,
             "capabilities": self.capabilities,
-            "handlers": list(self.handlers.keys())
+            "handlers": list(self.handlers.keys()),
+            "metadata": self.metadata
         }
 
 


### PR DESCRIPTION
## Summary
- add `metadata` attribute to `GenesisAgent`
- provide `set_metadata` and `get_metadata`
- include `metadata` in `get_info`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_logger' ...)*

------
https://chatgpt.com/codex/tasks/task_e_686ec269490c8325a701cdd91ee860fb