### PR TITLE
Implement config initialization helper

### DIFF
--- a/genesis_engine/cli/main.py
+++ b/genesis_engine/cli/main.py
@@ -20,7 +20,7 @@ from concurrent.futures import ThreadPoolExecutor
 # Importar componentes core
 from genesis_engine.core.exceptions import GenesisException, ProjectCreationError
 from genesis_engine.core.orchestrator import GenesisOrchestrator
-from genesis_engine.core.config import GenesisConfig
+from genesis_engine.core.config import initialize
 from genesis_engine.core.logging import get_logger
 from genesis_engine import __version__
 
@@ -144,7 +144,7 @@ def main(
         
     # Inicializar configuración
     try:
-        GenesisConfig.initialize()
+        initialize()
         if verbose:
             logger.info("Configuración inicializada en modo verbose")
     except Exception as e:
@@ -349,7 +349,7 @@ def doctor():
         # Verificar configuración
         console.print("\n[bold cyan]⚙️ Verificando configuración...[/bold cyan]")
         try:
-            GenesisConfig.initialize()
+            initialize()
             console.print("[green]✅ Configuración OK[/green]")
         except Exception as e:
             console.print(f"[red]❌ Error en configuración: {e}[/red]")

--- a/genesis_engine/core/config.py
+++ b/genesis_engine/core/config.py
@@ -326,6 +326,22 @@ def save_user_config(config: Optional[GenesisConfig] = None, config_file: Option
     
     config.save_to_file(config_file)
 
+def initialize(
+    config_file: Optional[Union[str, Path]] = None,
+    log_file: Optional[Union[str, Path]] = None,
+    level: Optional[str] = None,
+    enable_rich: Optional[bool] = None,
+) -> GenesisConfig:
+    """Inicializar configuración y logging de Genesis Engine."""
+
+    # Cargar configuración de usuario
+    config = load_user_config(config_file)
+
+    # Configurar logging y variables de entorno
+    setup_logging(level=level, log_file=log_file, enable_rich=enable_rich)
+    configure_environment()
+
+    return config
+
 # Configuración por defecto al importar el módulo
-if _config_instance is None:
-    _config_instance = load_user_config()
+if _config_instance is None:    _config_instance = load_user_config()


### PR DESCRIPTION
## Summary
- add `initialize` function to load config and setup logging
- switch CLI to use the new helper

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_logger' from partially initialized module)*

------
https://chatgpt.com/codex/tasks/task_e_686ec3400c6c8325934d4f42c9ee46c3