### PR TITLE
Implement metadata handling in GenesisAgent

### DIFF
--- a/genesis_engine/core/logging.py
+++ b/genesis_engine/core/logging.py
@@ -1,4 +1,3 @@
-from genesis_engine.core.logging import get_logger
 import logging
 from pathlib import Path
 from typing import Optional

--- a/genesis_engine/mcp/agent_base.py
+++ b/genesis_engine/mcp/agent_base.py
@@ -90,6 +90,7 @@ class GenesisAgent(ABC):
         self.handlers: Dict[str, Callable] = {}
         self.version = "1.0.0"
         self.logger = logging.getLogger(f"agent.{self.agent_id}")
+        self.metadata: Dict[str, Any] = {}
         
         # Registrar handlers básicos requeridos por MCP
         self._register_core_handlers()
@@ -284,7 +285,15 @@ class GenesisAgent(ABC):
     def has_capability(self, capability: str) -> bool:
         """Verificar si el agente tiene una capacidad específica"""
         return capability in self.capabilities
-    
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        """Guardar información arbitraria sobre el agente."""
+        self.metadata[key] = value
+
+    def get_metadata(self, key: str, default=None) -> Any:
+        """Obtener un valor de metadata almacenada."""
+        return self.metadata.get(key, default)
+
     def get_info(self) -> Dict[str, Any]:
         """Obtener información completa del agente"""
         return {
@@ -294,7 +303,8 @@ class GenesisAgent(ABC):
             "status": self.status,
             "version": self.version,
             "capabilities": self.capabilities,
-            "handlers": list(self.handlers.keys())
+            "handlers": list(self.handlers.keys()),
+            "metadata": self.metadata,
         }
 
 

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -18,7 +18,7 @@ import fnmatch
 from datetime import datetime
 import asyncio
 from genesis_engine.core.logging import get_logger
-from genesis_engine.core.config import GenesisConfig
+from genesis_engine.core.config import get_config
 
 from jinja2 import Environment, FileSystemLoader, Template, TemplateError
 from jinja2.exceptions import TemplateNotFound, TemplateSyntaxError
@@ -69,7 +69,7 @@ class TemplateEngine:
     def __init__(self, templates_dir: Optional[Path] = None, strict_validation: Optional[bool] = None):
         self.templates_dir = templates_dir or self._get_default_templates_dir()
         if strict_validation is None:
-            strict_validation = GenesisConfig.get("strict_template_validation", True)
+            strict_validation = get_config().__dict__.get("strict_template_validation", True)
         self.strict_validation = strict_validation
         self.env = self._setup_jinja_environment()
         self.logger = get_logger("genesis.template_engine")


### PR DESCRIPTION
## Summary
- add a `metadata` dictionary to `GenesisAgent`
- expose `set_metadata` and `get_metadata`
- include metadata in `get_info`
- fix template engine config call
- clean circular import in logging utility

## Testing
- `pytest tests/test_devops_agent.py::test_generate_docker_config -q`
- `pytest -q` *(fails: ImportError for BackendConfig and Orchestrator)*

------
https://chatgpt.com/codex/tasks/task_e_686ec340346c832598f953955532d4a2