### PR TITLE
Fix orchestrator shutdown log indentation

### DIFF
--- a/genesis_engine/core/orchestrator.py
+++ b/genesis_engine/core/orchestrator.py
@@ -1345,7 +1345,7 @@ Generado con ❤️ por Genesis Engine
         
         # Limpiar persistence
         await self._cleanup_persistence()
-                self.logger.info("🛑 Orchestrator detenido")
+        self.logger.info("🛑 Orchestrator detenido")
 
 
 # Backwards compatibility alias


### PR DESCRIPTION
## Summary
- align shutdown log line with surrounding code
- verify `orchestrator.py` compiles
- run tests

## Testing
- `python -m py_compile genesis_engine/core/orchestrator.py`
- `pip install -e ".[dev]"`
- `pytest -q` *(fails: AttributeError in tests, but no ImportErrors)*

------
https://chatgpt.com/codex/tasks/task_e_686ecbdc85ac83258a6cecc375007d93