### PR TITLE
Fix missing asyncio import in template engine tests

### DIFF
--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import asyncio
 
 import types
 


### PR DESCRIPTION
## Summary
- ensure `tests/test_template_engine.py` imports `asyncio`

## Testing
- `pytest -k template_engine -q` *(fails: TypeError, KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_686edb72bc248325ac0184a4151862fa