### PR TITLE
Add async start/stop wrappers

### DIFF
--- a/genesis_engine/core/orchestrator.py
+++ b/genesis_engine/core/orchestrator.py
@@ -249,6 +249,14 @@ class GenesisOrchestrator:
             "circuit_breaker_trips": 0,
             "average_execution_time": 0.0
         }
+
+    async def start(self):
+        """Wrapper asincrónico para inicializar el orquestador"""
+        await self.initialize()
+
+    async def stop(self):
+        """Wrapper asincrónico para detener el orquestador"""
+        await self.shutdown()
     
     async def initialize(self):
         """Inicializar el orquestador"""


### PR DESCRIPTION
## Summary
- add `start` and `stop` async wrappers in `GenesisOrchestrator`
- keep backwards compat alias `Orchestrator`

## Testing
- `pytest tests/test_orchestrator.py -q`
- `pytest -q` *(fails: async def functions are not natively supported, missing CLI modules, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686edb71f6088325b046700a560b1f09