### PR TITLE
Add MCP protocol property alias

### DIFF
--- a/genesis_engine/core/orchestrator.py
+++ b/genesis_engine/core/orchestrator.py
@@ -250,6 +250,11 @@ class GenesisOrchestrator:
             "average_execution_time": 0.0
         }
 
+    @property
+    def protocol(self) -> MCPProtocol:
+        # Alias retained for backward compatibility with earlier interface
+        return self.mcp
+
     async def start(self):
         """Wrapper asincrónico para inicializar el orquestador"""
         await self.initialize()


### PR DESCRIPTION
## Summary
- expose orchestrator MCP protocol via new `protocol` property
- note the property is for backwards compatibility

## Testing
- `pytest -q` *(fails: async functions not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_686ee47c2eb883258502569afc10c00b