### PR TITLE
Ensure MCP protocol tasks cleaned up

### DIFF
--- a/tests/test_critical_mcp_agents.py
+++ b/tests/test_critical_mcp_agents.py
@@ -79,6 +79,9 @@ class TestMCPProtocolCriticalFixed:
             
         finally:
             await protocol.stop()
+            assert protocol.worker_task.done()
+            assert protocol.metrics_task.done()
+            assert protocol.circuit_task.done()
 
 
 class TestAgentBaseCriticalFixed:

--- a/tests/test_genesis_framework.py
+++ b/tests/test_genesis_framework.py
@@ -219,8 +219,13 @@ class GenesisFrameworkTester:
             
             # Detener protocolo
             await protocol.stop()
+            assert protocol.worker_task.done()
+            assert protocol.metrics_task.done()
+            assert protocol.circuit_task.done()
             
         except Exception as e:
+            if 'protocol' in locals() and protocol.running:
+                await protocol.stop()
             self.add_result(TestResult(
                 name="MCP Protocol Test",
                 success=False,

--- a/tests/test_protocol_tasks.py
+++ b/tests/test_protocol_tasks.py
@@ -1,0 +1,11 @@
+import pytest
+from genesis_engine.mcp.protocol import MCPProtocol
+
+@pytest.mark.asyncio
+async def test_protocol_tasks_cleanup():
+    protocol = MCPProtocol()
+    await protocol.start()
+    await protocol.stop()
+    assert protocol.worker_task.done()
+    assert protocol.metrics_task.done()
+    assert protocol.circuit_task.done()


### PR DESCRIPTION
## Summary
- store background tasks in MCPProtocol
- cancel maintenance tasks on stop
- verify worker and maintenance tasks cleanup in tests

## Testing
- `pytest -q tests/test_protocol_tasks.py -s`

------
https://chatgpt.com/codex/tasks/task_e_686efdb2440083259da0179a4c438695