### PR TITLE
Make optional frontend vars

### DIFF
--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -175,12 +175,17 @@ class TemplateEngine:
 
         missing = set()
 
+        optional_non_strict = {"styling", "state_management"}
+
         # Reglas específicas por patrón de template
         for pattern, required in self.REQUIRED_VARIABLES.items():
             if fnmatch.fnmatch(template_name, pattern):
                 for name in required:
                     if name not in variables:
-                        missing.add(name)
+                        if not self.strict_validation and name in optional_non_strict:
+                            variables[name] = ""
+                        else:
+                            missing.add(name)
 
         # Validación genérica basada en variables esperadas dentro del template
         expected = set(self.get_template_variables(template_name))


### PR DESCRIPTION
## Summary
- allow `styling` and `state_management` to be optional when `strict_validation` is disabled
- update template engine tests for sync/async usage
- add tests for optional frontend variables

## Testing
- `pytest -k template_engine -q`
- `pytest -q` *(fails: async tests & others)*

------
https://chatgpt.com/codex/tasks/task_e_686efda66e10832597db7f7c4e98d060