### PR TITLE
Remove styling from required vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [Unreleased]
 ### Changed
 - Updated FastAPI templates to use `fastapi==0.115.14` and `uvicorn[standard]==0.35.0`.
+- Relaxed template validation by no longer requiring the `styling` variable for React and Next.js templates.

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -50,14 +50,12 @@ class TemplateEngine:
             "project_name",
             "description",
             "typescript",
-            "styling",
             "state_management",
         ],
         "frontend/react/*": [
             "project_name",
             "description",
             "typescript",
-            "styling",
             "state_management",
         ],
         "saas-basic/*": [


### PR DESCRIPTION
## Summary
- relax validation for frontend templates by removing the `styling` field
- document updated validation in the changelog

## Testing
- `pytest -q`
- `pytest tests/test_template_engine.py::test_generate_project -q`

------
https://chatgpt.com/codex/tasks/task_e_686efdd024a08325a44ade9a37d76572