### PR TITLE
Fix validation exception type

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ template_engine.register_template(
 
 # Al renderizar se validará que todas las variables requeridas para
 # cada plantilla estén presentes. Si falta alguna variable necesaria
-# se lanzará una `KeyError`.
+# se lanzará una `ValueError`.
 ```
 
 ### Hooks y Extensiones

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -192,7 +192,7 @@ class TemplateEngine:
         if missing:
             message = f"Variables faltantes para {template_name}: {', '.join(sorted(missing))}"
             if self.strict_validation:
-                raise KeyError(message)
+                raise ValueError(message)
             else:
                 self.logger.warning(message)
                 # Agregar variables por defecto para evitar errores
@@ -228,7 +228,7 @@ class TemplateEngine:
         # Validar variables requeridas (flexible para compatibilidad)
         try:
             self.validate_required_variables(template_name, vars_clean)
-        except KeyError as e:
+        except ValueError as e:
             if self.strict_validation:
                 raise ValueError(str(e))
             else:
@@ -368,7 +368,7 @@ class TemplateEngine:
                     # Validar variables requeridas (flexible para compatibilidad)
                     try:
                         self.validate_required_variables(relative_template.as_posix(), context)
-                    except KeyError as e:
+                    except ValueError as e:
                         self.logger.warning(f"Missing variables for {relative_template}, using defaults")
                         # Agregar variables por defecto para evitar errores
                         if 'project_name' not in context:


### PR DESCRIPTION
## Summary
- raise `ValueError` instead of `KeyError` when template variables are missing
- document the change in README

## Testing
- `pytest tests/test_template_engine.py -q` *(fails: 'coroutine' object is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_686efdb004fc832583f6e3c1f00db02e