### PR TITLE
Add synchronous wrapper for template generation

### DIFF
--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -400,7 +400,7 @@ class TemplateEngine:
         self.logger.info(f"Generated {len(generated_files)} files in {output_path}")
         return generated_files
 
-    async def generate_project(
+    async def generate_project_async(
         self,
         template_name: str,
         output_dir: Union[str, Path],
@@ -411,14 +411,16 @@ class TemplateEngine:
             self.generate_project_sync, template_name, output_dir, context
         )
 
-    async def generate_project_async(
+    def generate_project(
         self,
         template_name: str,
         output_dir: Union[str, Path],
         context: Optional[Dict[str, Any]] = None,
     ) -> List[Path]:
-        """Renderizar todas las plantillas dentro de un directorio de forma asíncrona"""
-        return await self.generate_project(template_name, output_dir, context)
+        """Generar proyecto de forma síncrona."""
+        return asyncio.run(
+            self.generate_project_async(template_name, output_dir, context)
+        )
     
     def validate_template(self, template_name: str) -> Dict[str, Any]:
         """

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -102,5 +102,7 @@ def test_missing_required_variables_generate(tmp_path: Path):
     out_dir = tmp_path / "out"
 
     with pytest.raises(ValueError):
-        asyncio.run(engine.generate_project("sample", out_dir, {"project_name": "demo"}))
+        asyncio.run(
+            engine.generate_project_async("sample", out_dir, {"project_name": "demo"})
+        )
 


### PR DESCRIPTION
## Summary
- wrap template generation with a synchronous helper
- update tests for new async method name

## Testing
- `pytest tests/test_template_engine.py::test_generate_project -q`
- `pytest -q` *(fails: 8 failed, 60 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686efdaeaca483258f1ecdb134d9f744