### PR TITLE
Fix CLI tests to create temporary genesis.json

### DIFF
--- a/tests/test_cli_deploy.py
+++ b/tests/test_cli_deploy.py
@@ -12,7 +12,7 @@ from genesis_engine.cli.main import app
 from genesis_engine.cli import commands as cmd_modules
 
 
-def test_genesis_deploy(monkeypatch):
+def test_genesis_deploy(monkeypatch, tmp_path):
     class DummyDeployAgent:
         async def initialize(self):
             pass
@@ -26,9 +26,19 @@ def test_genesis_deploy(monkeypatch):
 
     monkeypatch.setattr(cmd_modules.deploy, "DeployAgent", DummyDeployAgent)
 
+    # create temporary genesis.json so CLI detects a project
+    genesis_file = tmp_path / "genesis.json"
+    genesis_file.write_text("{}")
+    monkeypatch.chdir(tmp_path)
+
+    async def dummy_async(config):
+        return {"success": True, "url": "http://localhost"}
+
+    monkeypatch.setattr("genesis_engine.cli.main._deploy_async", dummy_async)
+
     runner = CliRunner()
     result = runner.invoke(app, ["deploy"])
     assert result.exit_code == 0
-    assert "Despliegue completado" in result.output
+    assert "Despliegue exitoso" in result.output
 
 

--- a/tests/test_cli_generate.py
+++ b/tests/test_cli_generate.py
@@ -12,7 +12,7 @@ from genesis_engine.cli.main import app
 from genesis_engine.cli import commands as cmd_modules
 
 
-def test_genesis_generate(monkeypatch):
+def test_genesis_generate(monkeypatch, tmp_path):
     class DummyBackendAgent:
         async def initialize(self):
             pass
@@ -22,8 +22,18 @@ def test_genesis_generate(monkeypatch):
 
     monkeypatch.setattr(cmd_modules.generate, 'BackendAgent', DummyBackendAgent)
 
+    # create temporary genesis.json so CLI detects a project
+    genesis_file = tmp_path / "genesis.json"
+    genesis_file.write_text("{}")
+    monkeypatch.chdir(tmp_path)
+
+    async def dummy_async(config):
+        return {"success": True, "files": ["models/user.py"]}
+
+    monkeypatch.setattr("genesis_engine.cli.main._generate_async", dummy_async)
+
     runner = CliRunner()
     result = runner.invoke(app, ['generate', 'model', 'User'])
     assert result.exit_code == 0
-    assert 'Generación completada' in result.output
+    assert "generado exitosamente" in result.output
 


### PR DESCRIPTION
## Summary
- add temp genesis.json for CLI tests
- patch async helpers and check for success messages

## Testing
- `pytest tests/test_cli_generate.py tests/test_cli_deploy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f013b1d9c8325bd90a18f6072967f