### PR TITLE
Add get_status to orchestrator

### DIFF
--- a/genesis_engine/core/orchestrator.py
+++ b/genesis_engine/core/orchestrator.py
@@ -537,6 +537,21 @@ class GenesisOrchestrator:
     def get_available_templates(self) -> List[str]:
         """Obtener lista de templates disponibles."""
         return ["saas-basic", "microservices", "ai-ready"]
+
+    def get_status(self) -> Dict[str, Any]:
+        """Obtener información general del orquestador.
+
+        Returns:
+            dict: Datos clave del estado actual, incluyendo si el
+            orquestador está corriendo, cuántos agentes hay registrados,
+            el workflow activo y el estado del protocolo MCP.
+        """
+        return {
+            "running": self.running,
+            "agents_registered": len(self.agents),
+            "current_workflow": self.current_workflow,
+            "mcp_running": getattr(self.mcp, "running", False),
+        }
     
     async def create_project(self, config: Dict[str, Any]) -> ProjectCreationResult:
         """


### PR DESCRIPTION
## Summary
- extend `GenesisOrchestrator` with a `get_status` helper that reports basic status info
- make sure orchestrator tests run

## Testing
- `pytest -q tests/test_orchestrator.py::test_process_request_success tests/test_orchestrator.py::test_process_request_unknown_agent tests/test_orchestrator.py::test_init_command_calls_design_architecture tests/test_genesis_framework.py::test_orchestrator -q`

------
https://chatgpt.com/codex/tasks/task_e_686f25dc218083258a1049f16cee32b8