### PR TITLE
Fix CLI test for updated env validation API

### DIFF
--- a/tests/test_genesis_framework.py
+++ b/tests/test_genesis_framework.py
@@ -355,12 +355,21 @@ class GenesisFrameworkTester:
             from genesis_engine.core.config import validate_environment
             
             env_validation = validate_environment()
-            
+
+            failed_checks = [
+                f"{name}: {info['message']}"
+                for name, info in env_validation["checks"].items()
+                if not info.get("success")
+            ]
+
             self.add_result(TestResult(
                 name="Environment Validation",
-                success=env_validation["valid"],
-                error="; ".join(env_validation["errors"]) if env_validation["errors"] else None,
-                details=f"Dependencies checked: {len(env_validation['dependency_checks'])}"
+                success=env_validation["overall_success"],
+                error="; ".join(failed_checks) if failed_checks else None,
+                details=(
+                    f"Checks passed: {env_validation['passed']}"
+                    f"/{env_validation['total_checks']}"
+                )
             ))
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- update environment validation checks for new `overall_success` key
- gather failure details from `checks` structure

## Testing
- `pytest tests/test_genesis_framework.py::test_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_686f25daabe88325b807eb5e6ac5ecfe