### PR TITLE
Refactor CLI tests to use mocks

### DIFF
--- a/tests/test_cli_deploy.py
+++ b/tests/test_cli_deploy.py
@@ -2,6 +2,9 @@ from pathlib import Path
 import sys
 import types
 from typer.testing import CliRunner
+from unittest.mock import Mock, AsyncMock
+
+from genesis_engine.agents.deploy import DeployAgent
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -13,32 +16,34 @@ from genesis_engine.cli import commands as cmd_modules
 
 
 def test_genesis_deploy(monkeypatch, tmp_path):
-    class DummyDeployAgent:
-        async def initialize(self):
-            pass
+    mock_deploy_cls = Mock(spec=DeployAgent)
+    mock_agent = mock_deploy_cls.return_value
+    mock_agent.initialize = AsyncMock()
+    mock_agent.execute_task = AsyncMock(
+        return_value=types.SimpleNamespace(
+            success=True,
+            urls=["http://localhost"],
+            error=None,
+        )
+    )
 
-        async def execute_task(self, task):
-            return types.SimpleNamespace(
-                success=True,
-                urls=["http://localhost"],
-                error=None,
-            )
-
-    monkeypatch.setattr(cmd_modules.deploy, "DeployAgent", DummyDeployAgent)
+    monkeypatch.setattr(cmd_modules.deploy, "DeployAgent", mock_deploy_cls)
 
     # create temporary genesis.json so CLI detects a project
     genesis_file = tmp_path / "genesis.json"
     genesis_file.write_text("{}")
     monkeypatch.chdir(tmp_path)
 
-    async def dummy_async(config):
-        return {"success": True, "url": "http://localhost"}
-
-    monkeypatch.setattr("genesis_engine.cli.main._deploy_async", dummy_async)
+    deploy_async = AsyncMock(return_value={"success": True, "url": "http://localhost"})
+    monkeypatch.setattr("genesis_engine.cli.main._deploy_async", deploy_async)
 
     runner = CliRunner()
     result = runner.invoke(app, ["deploy"])
     assert result.exit_code == 0
     assert "Despliegue exitoso" in result.output
+
+    deploy_async.assert_awaited_once_with(
+        {"environment": "local", "force": False, "auto_migrate": True}
+    )
 
 

--- a/tests/test_cli_generate.py
+++ b/tests/test_cli_generate.py
@@ -2,6 +2,9 @@ from pathlib import Path
 import sys
 import types
 from typer.testing import CliRunner
+from unittest.mock import Mock, AsyncMock
+
+from genesis_engine.agents.backend import BackendAgent
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -13,27 +16,32 @@ from genesis_engine.cli import commands as cmd_modules
 
 
 def test_genesis_generate(monkeypatch, tmp_path):
-    class DummyBackendAgent:
-        async def initialize(self):
-            pass
+    mock_backend_cls = Mock(spec=BackendAgent)
+    mock_backend = mock_backend_cls.return_value
+    mock_backend.initialize = AsyncMock()
+    mock_backend.execute_task = AsyncMock(return_value={"generated_files": ["models/user.py"]})
 
-        async def execute_task(self, task):
-            return {"generated_files": ["models/user.py"]}
-
-    monkeypatch.setattr(cmd_modules.generate, 'BackendAgent', DummyBackendAgent)
+    monkeypatch.setattr(cmd_modules.generate, 'BackendAgent', mock_backend_cls)
 
     # create temporary genesis.json so CLI detects a project
     genesis_file = tmp_path / "genesis.json"
     genesis_file.write_text("{}")
     monkeypatch.chdir(tmp_path)
 
-    async def dummy_async(config):
-        return {"success": True, "files": ["models/user.py"]}
-
-    monkeypatch.setattr("genesis_engine.cli.main._generate_async", dummy_async)
+    generate_async = AsyncMock(return_value={"success": True, "files": ["models/user.py"]})
+    monkeypatch.setattr("genesis_engine.cli.main._generate_async", generate_async)
 
     runner = CliRunner()
     result = runner.invoke(app, ['generate', 'model', 'User'])
     assert result.exit_code == 0
     assert "generado exitosamente" in result.output
+
+    generate_async.assert_awaited_once_with(
+        {
+            "component": "model",
+            "name": "User",
+            "agent": None,
+            "interactive": True,
+        }
+    )
 


### PR DESCRIPTION
## Summary
- replace dummy agent classes in CLI tests with mocks
- assert asynchronous calls with proper parameters

## Testing
- `pytest tests/test_cli_deploy.py::test_genesis_deploy -q`
- `pytest tests/test_cli_generate.py::test_genesis_generate -q`


------
https://chatgpt.com/codex/tasks/task_e_68707245300083259f4ae73b1f502b1d