### PR TITLE
Remove sys.path hacks from tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 from pathlib import Path
-import sys
+import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
+
+@pytest.fixture(scope="session")
+def genesis_root():
+    """Return repository root directory."""
+    return Path(__file__).resolve().parents[1]
 
 import yaml
 import genesis_engine

--- a/tests/test_agent_base_async.py
+++ b/tests/test_agent_base_async.py
@@ -1,10 +1,5 @@
 import asyncio
-import sys
-from pathlib import Path
 import pytest
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.mcp.agent_base import create_simple_agent
 from genesis_engine.mcp.message_types import MCPRequest

--- a/tests/test_agents_instantiation.py
+++ b/tests/test_agents_instantiation.py
@@ -1,8 +1,4 @@
-from pathlib import Path
-import sys
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.agents.architect import ArchitectAgent
 from genesis_engine.agents.backend import BackendAgent

--- a/tests/test_ai_ready_agent.py
+++ b/tests/test_ai_ready_agent.py
@@ -6,17 +6,16 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
-# Stub core.config before importing TemplateEngine
-spec = importlib.util.spec_from_file_location(
-    'genesis_engine.core.config', ROOT / 'genesis_engine' / 'core' / 'config.py'
-)
-config_mod = importlib.util.module_from_spec(spec)
-sys.modules['genesis_engine.core.config'] = config_mod
-spec.loader.exec_module(config_mod)
-config_mod.GenesisConfig.get = classmethod(lambda cls, key, default=None: default)
+def load_config(genesis_root):
+    spec = importlib.util.spec_from_file_location(
+        'genesis_engine.core.config', genesis_root / 'genesis_engine' / 'core' / 'config.py'
+    )
+    config_mod = importlib.util.module_from_spec(spec)
+    sys.modules['genesis_engine.core.config'] = config_mod
+    spec.loader.exec_module(config_mod)
+    config_mod.GenesisConfig.get = classmethod(lambda cls, key, default=None: default)
+    return config_mod
 
 # Stub core.logging to avoid circular import
 logging_mod = types.ModuleType('genesis_engine.core.logging')
@@ -30,7 +29,8 @@ from genesis_engine.mcp.agent_base import AgentTask
 
 
 @pytest.mark.asyncio
-async def test_ai_ready_agent_main_handlers(tmp_path):
+async def test_ai_ready_agent_main_handlers(genesis_root, tmp_path):
+    load_config(genesis_root)
     agent = AIReadyAgent()
     # Provide missing set_metadata method
     agent.metadata = {}

--- a/tests/test_architect_agent.py
+++ b/tests/test_architect_agent.py
@@ -1,8 +1,4 @@
-from pathlib import Path
-import sys
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.agents.architect import ArchitectAgent
 

--- a/tests/test_backend_generation.py
+++ b/tests/test_backend_generation.py
@@ -1,12 +1,6 @@
 from pathlib import Path
 import asyncio
 
-import sys
-
-# Ensure repo root on path
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
-
 from genesis_engine.agents.backend import (
     BackendAgent,
     BackendConfig,
@@ -16,10 +10,10 @@ from genesis_engine.agents.backend import (
 )
 from genesis_engine.templates.engine import TemplateEngine
 
-def make_agent():
+def make_agent(genesis_root):
     agent = BackendAgent()
     agent.template_engine = TemplateEngine(
-        ROOT / 'genesis_engine' / 'templates' / 'backend'
+        genesis_root / 'genesis_engine' / 'templates' / 'backend'
     )
     # Register missing filter used in templates
     agent.template_engine.register_filter('sql_type', agent.template_engine._get_sql_type)
@@ -27,8 +21,8 @@ def make_agent():
     return agent
 
 
-def test_generate_data_models(tmp_path):
-    agent = make_agent()
+def test_generate_data_models(genesis_root, tmp_path):
+    agent = make_agent(genesis_root)
     schema = {
         'entities': [
             {
@@ -59,8 +53,8 @@ def test_generate_data_models(tmp_path):
     assert 'class UserBase' in expected_schema.read_text()
 
 
-def test_setup_database_config(tmp_path, monkeypatch):
-    agent = make_agent()
+def test_setup_database_config(genesis_root, tmp_path, monkeypatch):
+    agent = make_agent(genesis_root)
     config = BackendConfig(
         framework=BackendFramework.FASTAPI,
         database=DatabaseType.POSTGRESQL,
@@ -95,8 +89,8 @@ def test_setup_database_config(tmp_path, monkeypatch):
     assert migration_file.read_text() == 'alembic'
 
 
-def test_setup_authentication(tmp_path, monkeypatch):
-    agent = make_agent()
+def test_setup_authentication(genesis_root, tmp_path, monkeypatch):
+    agent = make_agent(genesis_root)
     config = BackendConfig(
         framework=BackendFramework.FASTAPI,
         database=DatabaseType.POSTGRESQL,
@@ -122,28 +116,28 @@ def test_setup_authentication(tmp_path, monkeypatch):
     assert expected_file.read_text() == 'auth'
 
 
-def test_load_framework_configs():
-    agent = make_agent()
+def test_load_framework_configs(genesis_root):
+    agent = make_agent(genesis_root)
     configs = agent.framework_configs
     assert 'fastapi' in configs
     assert 'nestjs' in configs
 
 
-def test_load_code_templates():
-    agent = make_agent()
+def test_load_code_templates(genesis_root):
+    agent = make_agent(genesis_root)
     agent._load_code_templates()
     assert any(t.endswith('main.py.j2') for t in agent.available_templates)
 
 
-def test_setup_code_generators():
-    agent = make_agent()
+def test_setup_code_generators(genesis_root):
+    agent = make_agent(genesis_root)
     agent._setup_code_generators()
     assert 'nestjs_controller' in agent.code_generators
     assert agent.code_generators['nestjs_controller'] == agent._generate_nestjs_controller
 
 
-def test_generate_nestjs_controller(tmp_path):
-    agent = make_agent()
+def test_generate_nestjs_controller(genesis_root, tmp_path):
+    agent = make_agent(genesis_root)
     config = BackendConfig(
         framework=BackendFramework.NESTJS,
         database=DatabaseType.POSTGRESQL,
@@ -159,8 +153,8 @@ def test_generate_nestjs_controller(tmp_path):
     assert 'class UserController' in file.read_text()
 
 
-def test_generate_typeorm_config(tmp_path):
-    agent = make_agent()
+def test_generate_typeorm_config(genesis_root, tmp_path):
+    agent = make_agent(genesis_root)
     config = BackendConfig(
         framework=BackendFramework.NESTJS,
         database=DatabaseType.POSTGRESQL,
@@ -175,8 +169,8 @@ def test_generate_typeorm_config(tmp_path):
     assert 'DataSource' in file.read_text()
 
 
-def test_generate_fastapi_jwt_auth(tmp_path):
-    agent = make_agent()
+def test_generate_fastapi_jwt_auth(genesis_root, tmp_path):
+    agent = make_agent(genesis_root)
     config = BackendConfig(
         framework=BackendFramework.FASTAPI,
         database=DatabaseType.POSTGRESQL,
@@ -191,8 +185,8 @@ def test_generate_fastapi_jwt_auth(tmp_path):
     assert 'SECRET_KEY' in file.read_text()
 
 
-def test_generate_nestjs_jwt_auth(tmp_path):
-    agent = make_agent()
+def test_generate_nestjs_jwt_auth(genesis_root, tmp_path):
+    agent = make_agent(genesis_root)
     config = BackendConfig(
         framework=BackendFramework.NESTJS,
         database=DatabaseType.POSTGRESQL,
@@ -207,8 +201,8 @@ def test_generate_nestjs_jwt_auth(tmp_path):
     assert 'jwtConstants' in file.read_text()
 
 
-def test_generate_dockerfile_python(tmp_path):
-    agent = make_agent()
+def test_generate_dockerfile_python(genesis_root, tmp_path):
+    agent = make_agent(genesis_root)
     config = BackendConfig(
         framework=BackendFramework.FASTAPI,
         database=DatabaseType.POSTGRESQL,
@@ -223,8 +217,8 @@ def test_generate_dockerfile_python(tmp_path):
     assert 'FROM python' in file.read_text()
 
 
-def test_generate_api_documentation(tmp_path):
-    agent = make_agent()
+def test_generate_api_documentation(genesis_root, tmp_path):
+    agent = make_agent(genesis_root)
     config = BackendConfig(
         framework=BackendFramework.FASTAPI,
         database=DatabaseType.POSTGRESQL,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,6 @@
-from pathlib import Path
 import sys
 import types
 from typer.testing import CliRunner
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 import yaml  # ensure PyYAML is available

--- a/tests/test_cli_deploy.py
+++ b/tests/test_cli_deploy.py
@@ -1,10 +1,5 @@
-from pathlib import Path
-import sys
 import types
 from typer.testing import CliRunner
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 import yaml
 

--- a/tests/test_cli_generate.py
+++ b/tests/test_cli_generate.py
@@ -1,10 +1,6 @@
 from pathlib import Path
-import sys
 import types
 from typer.testing import CliRunner
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 import yaml
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,8 +1,4 @@
-from pathlib import Path
 import sys
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.cli.main import app
 

--- a/tests/test_critical_mcp_agents.py
+++ b/tests/test_critical_mcp_agents.py
@@ -6,13 +6,10 @@ CORRECCIÓN: Capabilities esperadas actualizadas con las reales del ArchitectAge
 import pytest
 import asyncio
 from unittest.mock import Mock, AsyncMock
-import sys
 import os
+import sys
 import tempfile
 from pathlib import Path
-
-# Agregar el directorio raíz al path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 # CORRECCIÓN: Imports actualizados con estructura corregida
 from genesis_engine.mcp.protocol import MCPProtocol

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,17 +1,7 @@
-import importlib.util
 import types
-from pathlib import Path
-import sys
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-
-spec = importlib.util.spec_from_file_location(
-    'genesis_engine.cli.commands.utils',
-    ROOT / 'genesis_engine' / 'cli' / 'commands' / 'utils.py'
-)
-utils = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(utils)
+from genesis_engine.cli.commands import utils
 
 
 def test_check_dependencies_success(monkeypatch):

--- a/tests/test_deploy_cloud.py
+++ b/tests/test_deploy_cloud.py
@@ -1,9 +1,5 @@
-import sys
 from pathlib import Path
 import pytest
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 import genesis_engine.agents.deploy as deploy_mod
 from genesis_engine.agents.deploy import (

--- a/tests/test_devops_agent.py
+++ b/tests/test_devops_agent.py
@@ -1,9 +1,4 @@
 import asyncio
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.agents import devops as devops_mod
 from genesis_engine.agents.devops import (

--- a/tests/test_environment_validator.py
+++ b/tests/test_environment_validator.py
@@ -1,8 +1,4 @@
 from pathlib import Path
-import sys
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.utils.validation import EnvironmentValidator
 import genesis_engine.utils.validation as validation_mod

--- a/tests/test_frontend_generation.py
+++ b/tests/test_frontend_generation.py
@@ -1,8 +1,4 @@
 from pathlib import Path
-import sys
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.agents.frontend import FrontendAgent
 from genesis_engine.templates.engine import TemplateEngine
@@ -11,14 +7,14 @@ async def run_async(coro):
     return await coro
 
 
-def make_agent():
+def make_agent(genesis_root):
     agent = FrontendAgent()
-    agent.template_engine = TemplateEngine(ROOT / 'genesis_engine' / 'templates')
+    agent.template_engine = TemplateEngine(genesis_root / 'genesis_engine' / 'templates')
     return agent
 
 
-def test_generate_react_frontend(tmp_path):
-    agent = make_agent()
+def test_generate_react_frontend(genesis_root, tmp_path):
+    agent = make_agent(genesis_root)
     schema = {"project_name": "DemoApp", "description": "Demo"}
     params = {"schema": schema, "framework": "react", "output_path": tmp_path}
     result = agent._generate_complete_frontend(params)

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,24 +1,21 @@
 import importlib.util
 import logging
 import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
-
-# Load config module
-spec = importlib.util.spec_from_file_location(
-    'genesis_engine.core.config',
-    ROOT / 'genesis_engine' / 'core' / 'config.py'
-)
-config = importlib.util.module_from_spec(spec)
-sys.modules['genesis_engine.core.config'] = config
-spec.loader.exec_module(config)
-
-GenesisConfig = config.GenesisConfig
 
 
-def test_setup_logging_idempotent(tmp_path):
+def load_config(genesis_root):
+    spec = importlib.util.spec_from_file_location(
+        'genesis_engine.core.config',
+        genesis_root / 'genesis_engine' / 'core' / 'config.py'
+    )
+    config = importlib.util.module_from_spec(spec)
+    sys.modules['genesis_engine.core.config'] = config
+    spec.loader.exec_module(config)
+    return config.GenesisConfig
+
+
+def test_setup_logging_idempotent(genesis_root, tmp_path):
+    GenesisConfig = load_config(genesis_root)
     root_logger = logging.getLogger()
     original_handlers = list(root_logger.handlers)
     cfg = GenesisConfig()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,8 +1,4 @@
-import sys
 from pathlib import Path
-
-repo_root = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(repo_root))
 
 from genesis_engine.core.orchestrator import GenesisOrchestrator
 

--- a/tests/test_performance_agent.py
+++ b/tests/test_performance_agent.py
@@ -1,9 +1,5 @@
 from pathlib import Path
-import sys
 import pytest
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.agents.performance import PerformanceAgent
 

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -1,13 +1,9 @@
 from pathlib import Path
-import sys
 import asyncio
 
 import types
 
 import pytest
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.templates.engine import TemplateEngine
 

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -1,8 +1,4 @@
 from pathlib import Path
-import sys
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from genesis_engine.core.config import GenesisConfig
 from genesis_engine.utils.validation import ConfigValidator, ValidationLevel


### PR DESCRIPTION
## Summary
- add `genesis_root` fixture
- remove `sys.path` manipulation from tests and use fixture
- update tests to use installed package paths

## Testing
- `pip install -e .`
- `pip install pyyaml`
- `pip install httpx`
- `pip install pydantic-settings`
- `pytest -q` *(fails: `pydantic.errors.PydanticImportError`)*

------
https://chatgpt.com/codex/tasks/task_e_68707243e9888325a76776d0e4c64401