### PR TITLE
Fix BaseSettings import for FastAPI backend

### DIFF
--- a/my-saas-app/backend/app/core/config.py
+++ b/my-saas-app/backend/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from typing import List, Optional
 
 class Settings(BaseSettings):

--- a/my-saas-app/backend/requirements.txt
+++ b/my-saas-app/backend/requirements.txt
@@ -4,3 +4,4 @@ pydantic>=2.5.0
 python-dotenv>=1.0.0
 python-multipart>=0.0.6
 httpx>=0.24.0
+pydantic-settings==2.1.0


### PR DESCRIPTION
## Summary
- import `BaseSettings` from `pydantic_settings` instead of `pydantic`
- include `pydantic-settings` in backend requirements

## Testing
- `pytest -q my-saas-app/backend`

------
https://chatgpt.com/codex/tasks/task_e_68707438094c832599c4184710d7b8ef