### PR TITLE
Add port conflicts section

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -76,6 +76,31 @@ python verify_fixes.py
 pip install pydantic-settings
 ```
 
+### Conflictos de Puertos
+
+Al ejecutar `docker-compose up` cada servicio expone un puerto fijo en tu
+máquina. Por ejemplo, Grafana usa el **3001** y Prometheus el **9090**. Si otro
+proyecto ya está utilizando esos puertos obtendrás errores de arranque o los
+dashboards no estarán disponibles.
+
+**Opciones para resolverlo**:
+
+1. Detén las instancias de otros proyectos con `docker-compose down` o
+   `docker stop <id>` antes de iniciar uno nuevo.
+2. Cambia los puertos editando tu `docker-compose.yml`. Modifica el valor a la
+   izquierda del `:`. Ejemplo:
+
+   ```yaml
+   grafana:
+     ports:
+       - "3100:3000"  # host:contenedor
+   prometheus:
+     ports:
+       - "9091:9090"
+   ```
+
+Luego ejecuta nuevamente `docker-compose up -d`.
+
 ## Estructura del proyecto
 
 ```

--- a/README.md
+++ b/README.md
@@ -209,6 +209,26 @@ npm run dev
 # - API Docs: http://localhost:8000/docs
 ```
 
+### Conflictos de Puertos
+
+Algunos servicios del stack utilizan puertos fijos en tu máquina:
+
+- **Frontend**: 3000
+- **Backend**: 8000
+- **PostgreSQL**: 5432
+- **Prometheus**: 9090
+- **Grafana**: 3001
+
+Si otros proyectos están ocupando esos puertos, los contenedores no iniciarán
+o quedarán inaccesibles.
+
+1. Detén los proyectos que ya estén ejecutándose con `docker-compose down` o
+   `docker stop <id>`.
+2. O bien edita `docker-compose.yml` y cambia el número a la izquierda del `:`
+   para asignar un nuevo puerto en tu host.
+
+Después vuelve a ejecutar `docker-compose up -d` para iniciar los servicios.
+
 ## 🎨 Plantillas Disponibles
 
 ### Golden Path - SaaS Básico


### PR DESCRIPTION
## Summary
- document how fixed ports in Grafana and Prometheus can cause conflicts
- explain how to change ports or stop other projects before starting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6871b840fcf48325a5cb06136c240bbe