### PR TITLE
Add compatibility wrapper for docker compose generation

### DIFF
--- a/genesis_engine/agents/devops.py
+++ b/genesis_engine/agents/devops.py
@@ -485,24 +485,56 @@ jobs:
         config = params.get("config")
         output_path = Path(params.get("output_path", "./"))
         dockerfile_status = params.get("dockerfile_status", {})
-        
+
         generated_files = []
         stack = schema.get("stack", {})
-        
+
+        # Generate Dockerfiles based on stack
+        backend_framework = stack.get("backend")
+        if backend_framework:
+            backend_path = output_path / "backend"
+            dockerfile = await self._generate_python_dockerfile(backend_path, backend_framework)
+            if dockerfile:
+                generated_files.append(dockerfile)
+
+        frontend_framework = stack.get("frontend")
+        if frontend_framework:
+            frontend_path = output_path / "frontend"
+            if frontend_framework == "nextjs":
+                dockerfile = await self._generate_nextjs_dockerfile(frontend_path)
+            else:
+                dockerfile = await self._generate_node_dockerfile(frontend_path, frontend_framework)
+            if dockerfile:
+                generated_files.append(dockerfile)
+
         # docker-compose.yml - MEJORADO con verificación
-        compose_file = await self._generate_docker_compose_improved(output_path, schema, config, dockerfile_status)
+        compose_file = await self._generate_docker_compose(output_path, schema, config)
         generated_files.append(compose_file)
         
         # .dockerignore files
         dockerignore_files = await self._generate_dockerignore_files(output_path, stack)
         generated_files.extend(dockerignore_files)
-        
+
         return generated_files
 
+    async def _generate_docker_compose(
+        self,
+        output_path: Path,
+        schema: Dict[str, Any],
+        config: DevOpsConfig,
+        dockerfile_status: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Compatibilidad: delega en _generate_docker_compose_improved"""
+        if dockerfile_status is None:
+            dockerfile_status = await self._verify_project_dockerfiles(output_path, schema)
+        return await self._generate_docker_compose_improved(
+            output_path, schema, config, dockerfile_status
+        )
+
     async def _generate_docker_compose_improved(
-        self, 
-        output_path: Path, 
-        schema: Dict[str, Any], 
+        self,
+        output_path: Path,
+        schema: Dict[str, Any],
         config: DevOpsConfig,
         dockerfile_status: Dict[str, Any]
     ) -> str:


### PR DESCRIPTION
## Summary
- implement `_generate_docker_compose` wrapper delegating to `_generate_docker_compose_improved`
- generate backend and frontend Dockerfiles inside `_generate_docker_config`
- update calls to use the new wrapper
- keep tests working

## Testing
- `pytest tests/test_devops_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871b84072e483258e5ce22b3ddb8274