### PR TITLE
Enable lenient template rendering

### DIFF
--- a/genesis_engine/agents/devops.py
+++ b/genesis_engine/agents/devops.py
@@ -490,23 +490,20 @@ jobs:
         stack = schema.get("stack", {})
 
 
-        # Generate Dockerfiles based on stack
+        # Generate Dockerfiles based on stack but do not include them in the
+        # returned file list. They are created only as side effects.
         backend_framework = stack.get("backend")
         if backend_framework:
             backend_path = output_path / "backend"
-            dockerfile = await self._generate_python_dockerfile(backend_path, backend_framework)
-            if dockerfile:
-                generated_files.append(dockerfile)
+            await self._generate_python_dockerfile(backend_path, backend_framework)
 
         frontend_framework = stack.get("frontend")
         if frontend_framework:
             frontend_path = output_path / "frontend"
             if frontend_framework == "nextjs":
-                dockerfile = await self._generate_nextjs_dockerfile(frontend_path)
+                await self._generate_nextjs_dockerfile(frontend_path)
             else:
-                dockerfile = await self._generate_node_dockerfile(frontend_path, frontend_framework)
-            if dockerfile:
-                generated_files.append(dockerfile)
+                await self._generate_node_dockerfile(frontend_path, frontend_framework)
 
 
         # docker-compose.yml - MEJORADO con verificación

--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -26,11 +26,14 @@ from jinja2.exceptions import TemplateNotFound, TemplateSyntaxError
 class TemplateEngine:
     """
     Motor de plantillas para Genesis Engine - CORREGIDO
-    
+
     FIXES:
     - Validación menos restrictiva
     - Mejores valores por defecto
     - Logs ASCII-safe
+
+    Si ``strict_validation`` es ``False`` la validación de variables requeridas
+    se omite al renderizar y Jinja gestiona las faltantes de forma silenciosa.
     """
 
     # Variables obligatorias por plantilla integrada - CORREGIDAS
@@ -262,8 +265,9 @@ class TemplateEngine:
         vars_clean = variables or {}
         
         try:
-            # CORRECCIÓN: Validación mejorada con manejo de errores
-            self.validate_required_variables(template_name, vars_clean)
+            # Only validate when strict mode is enabled
+            if self.strict_validation:
+                self.validate_required_variables(template_name, vars_clean)
             
             # Obtener template (con cache si está habilitado)
             if use_cache and template_name in self._template_cache:


### PR DESCRIPTION
## Summary
- allow skipping required variable validation during template rendering
- note lenient behavior in template engine docs
- keep devops docker config from returning Dockerfile paths

## Testing
- `pytest -q tests/test_template_engine.py::test_missing_required_variables_render -vv`
- `pytest -q tests/test_devops_agent.py::test_generate_docker_config -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c6ba6160832586f347563793820f