### PR TITLE
Fix TemplateEngine non-strict rendering

### DIFF
--- a/genesis_engine/templates/engine.py
+++ b/genesis_engine/templates/engine.py
@@ -301,10 +301,9 @@ class TemplateEngine:
         except Exception as e:
             error_msg = f"Unexpected error rendering {template_name}: {e}"
             self.logger.error(f"[ERROR] {error_msg}")
-            # CORRECCIÓN: En lugar de fallar, intentar con template básico
-            if not self.strict_validation:
-                self.logger.warning(f"[WARN] Usando template básico para {template_name}")
-                return self._generate_fallback_content(template_name, vars_clean)
+            # En modo no estricto simplemente propagamos el error para que
+            # Jinja devuelva el contenido renderizado (variables faltantes se
+            # sustituyen por vacío). No generamos contenido de fallback.
             raise
 
     def _generate_fallback_content(self, template_name: str, variables: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- avoid generating fallback content when rendering templates in non-strict mode

## Testing
- `pytest tests/test_template_engine.py::test_missing_required_variables_render -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871caed3fb083258f1fb208963b3a86