### PR TITLE
Fix pydantic v2 settings import

### DIFF
--- a/genesis_engine/agents/backend.py
+++ b/genesis_engine/agents/backend.py
@@ -710,7 +710,7 @@ class AuthService:
         project_name = schema.get("project", {}).get("name", "Genesis API")
         features = schema.get("features", [])
         
-        config_content = f'''from pydantic import BaseSettings
+        config_content = f'''from pydantic_settings import BaseSettings
 from typing import List, Optional
 
 class Settings(BaseSettings):

--- a/tests/test_backend_generation.py
+++ b/tests/test_backend_generation.py
@@ -239,3 +239,10 @@ def test_generate_api_documentation(tmp_path):
     assert list(map(Path, paths)) == [file]
     assert 'API Documentation' in file.read_text()
 
+
+def test_generate_config_file_uses_pydantic_settings():
+    agent = make_agent()
+    schema = {'project': {'name': 'Demo'}, 'features': []}
+    config_content = agent._generate_config_file(schema)
+    assert 'from pydantic_settings import BaseSettings' in config_content
+


### PR DESCRIPTION
## Summary
- import `BaseSettings` from `pydantic_settings`
- test generated config file uses the new import

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871cc92e1f08325bfa4c0ce1c0d7be1