### PR TITLE
Fix Next.js main page generation

### DIFF
--- a/genesis_engine/agents/frontend.py
+++ b/genesis_engine/agents/frontend.py
@@ -252,6 +252,10 @@ class FrontendAgent(GenesisAgent):
             ts_files = self._generate_typescript_config(output_path, config)
             generated_files.extend(ts_files)
 
+        # 9. Páginas principales de Next.js
+        pages_files = self._generate_nextjs_pages(config, output_path)
+        generated_files.extend(pages_files)
+
         return {
             "framework": config.framework.value,
             "typescript": config.typescript,
@@ -543,7 +547,7 @@ class FrontendAgent(GenesisAgent):
             # app/layout.tsx
             layout_file = output_path / "app/layout.tsx"
             layout_file.parent.mkdir(parents=True, exist_ok=True)
-            
+
             layout_content = self.template_engine.render_template(
                 "frontend/nextjs/app/layout.tsx.j2",
                 template_vars
@@ -551,7 +555,7 @@ class FrontendAgent(GenesisAgent):
             layout_file.write_text(layout_content)
             generated_files.append(str(layout_file))
 
-            # app/page.tsx
+            # app/page.tsx (se genera posteriormente en _generate_main_page)
             page_file = output_path / "app/page.tsx"
             page_content = self.template_engine.render_template(
                 "frontend/nextjs/app/page.tsx.j2",
@@ -814,6 +818,176 @@ export type AppDispatch = typeof store.dispatch;"""
         
         output_file.write_text(content)
         return str(output_file)
+
+    def _generate_nextjs_pages(self, config: FrontendConfig, output_path: Path) -> List[str]:
+        """Generar páginas de Next.js"""
+        generated_files: List[str] = []
+
+        if config.framework == FrontendFramework.NEXTJS:
+            main_page = self._generate_main_page(config, output_path)
+            if main_page:
+                generated_files.append(main_page)
+
+        return generated_files
+
+    def _generate_main_page(self, config: FrontendConfig, output_path: Path) -> str:
+        """Generar página principal funcional (page.tsx)"""
+        app_dir = output_path / "app"
+        app_dir.mkdir(parents=True, exist_ok=True)
+
+        project_name = getattr(config, "project_name", "Genesis App")
+
+        page_content = f"""'use client'
+
+import {{ useEffect, useState }} from 'react'
+
+interface ApiResponse {{
+  message: string
+  status: string
+  project?: string
+}}
+
+export default function HomePage() {{
+  const [apiData, setApiData] = useState<ApiResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {{
+    const fetchData = async () => {{
+      try {{
+        const response = await fetch('http://localhost:8000/')
+        const data = await response.json()
+        setApiData(data)
+        setLoading(false)
+      }} catch (err) {{
+        setError(err instanceof Error ? err.message : 'Error connecting to backend')
+        setLoading(false)
+      }}
+    }}
+
+    fetchData()
+  }}, [])
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <div className="container mx-auto px-4 py-12">
+        <div className="max-w-4xl mx-auto">
+          
+          {{/* Header */}}
+          <div className="text-center mb-12">
+            <h1 className="text-5xl font-bold text-gray-900 mb-4">
+              🚀 {project_name}
+            </h1>
+            <p className="text-xl text-gray-600">
+              Generado exitosamente por Genesis Engine
+            </p>
+          </div>
+
+          {{/* Status Cards */}}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            
+            {{/* Frontend Status */}}
+            <div className="bg-white rounded-lg shadow-lg p-6 border-l-4 border-green-500">
+              <h3 className="text-lg font-semibold text-green-800 mb-2">
+                ✅ Frontend
+              </h3>
+              <p className="text-green-700 text-sm">Next.js + TypeScript</p>
+              <p className="text-green-700 text-sm">Puerto: 3000</p>
+            </div>
+
+            {{/* Backend Status */}}
+            <div className={{`bg-white rounded-lg shadow-lg p-6 border-l-4 ${{
+              loading ? 'border-yellow-500' : error ? 'border-red-500' : 'border-green-500'
+            }}`}}>
+              <h3 className={{`text-lg font-semibold mb-2 ${{
+                loading ? 'text-yellow-800' : error ? 'text-red-800' : 'text-green-800'
+              }}`}}>
+                {{loading ? '🔄' : error ? '❌' : '✅'}} Backend API
+              </h3>
+              {{loading ? (
+                <p className="text-yellow-700 text-sm">Conectando...</p>
+              ) : error ? (
+                <p className="text-red-700 text-sm">Error: {{error}}</p>
+              ) : (
+                <div>
+                  <p className="text-green-700 text-sm">FastAPI funcionando</p>
+                  <p className="text-green-700 text-sm">Puerto: 8000</p>
+                </div>
+              )}}
+            </div>
+
+            {{/* Database Status */}}
+            <div className="bg-white rounded-lg shadow-lg p-6 border-l-4 border-blue-500">
+              <h3 className="text-lg font-semibold text-blue-800 mb-2">
+                🗄️ Database
+              </h3>
+              <p className="text-blue-700 text-sm">PostgreSQL 15</p>
+              <p className="text-blue-700 text-sm">Puerto: 5432</p>
+            </div>
+          </div>
+
+          {{/* API Response */}}
+          {{!loading && !error && apiData && (
+            <div className="bg-white rounded-lg shadow-lg p-6 mb-8">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4">
+                📡 Respuesta del Backend
+              </h3>
+              <div className="bg-gray-50 rounded p-4">
+                <pre className="text-sm text-gray-700">
+                  {{JSON.stringify(apiData, null, 2)}}
+                </pre>
+              </div>
+            </div>
+          )}}
+
+          {{/* Action Buttons */}}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+            <a 
+              href="http://localhost:8000/docs"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-blue-600 text-white px-6 py-3 rounded-lg text-center hover:bg-blue-700 transition-colors font-medium"
+            >
+              📚 API Documentation
+            </a>
+            
+            <a 
+              href="http://localhost:3001"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-orange-600 text-white px-6 py-3 rounded-lg text-center hover:bg-orange-700 transition-colors font-medium"
+            >
+              📊 Grafana Dashboard
+            </a>
+            
+            <a 
+              href="http://localhost:9090"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-red-600 text-white px-6 py-3 rounded-lg text-center hover:bg-red-700 transition-colors font-medium"
+            >
+              🔍 Prometheus
+            </a>
+          </div>
+
+          {{/* Footer */}}
+          <div className="text-center text-gray-500 text-sm">
+            <p>🚀 Generado por Genesis Engine</p>
+            <p>Proyecto: {project_name} | Versión: 1.0.0</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}}
+"""
+
+        page_file = app_dir / "page.tsx"
+        with open(page_file, 'w', encoding='utf-8') as f:
+            f.write(page_content)
+
+        self.logger.info(f"✅ Página principal generada: {page_file}")
+        return str(page_file)
 
     def _generate_next_config(
         self, 


### PR DESCRIPTION
## Summary
- ensure Next.js main page gets generated
- implement `_generate_nextjs_pages` and `_generate_main_page`
- call page generation from frontend project build

## Testing
- `python -m py_compile genesis_engine/agents/frontend.py`
- `pytest -q` *(fails: Client.__init__ unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6871e9a519148325a04926f1423e3a24