### PR TITLE
Add home page template for Next.js frontend

### DIFF
--- a/genesis_engine/templates/frontend/nextjs/page.tsx.j2
+++ b/genesis_engine/templates/frontend/nextjs/page.tsx.j2
@@ -1,0 +1,185 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ApiResponse {
+  message: string
+  status: string
+  project?: string
+}
+
+export default function HomePage() {
+  const [apiData, setApiData] = useState<ApiResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch('{{ api_url | default("http://localhost:8000") }}/')
+        const data = await response.json()
+        setApiData(data)
+        setLoading(false)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error connecting to backend')
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <div className="container mx-auto px-4 py-12">
+        <div className="max-w-4xl mx-auto">
+          
+          {/* Header */}
+          <div className="text-center mb-12">
+            <h1 className="text-5xl font-bold text-gray-900 mb-4">
+              🚀 {{ project_name }}
+            </h1>
+            <p className="text-xl text-gray-600">
+              {{ description | default("Generado exitosamente por Genesis Engine") }}
+            </p>
+          </div>
+
+          {/* Status Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            
+            {/* Frontend Status */}
+            <div className="bg-white rounded-lg shadow-lg p-6 border-l-4 border-green-500">
+              <h3 className="text-lg font-semibold text-green-800 mb-2">
+                ✅ Frontend
+              </h3>
+              <p className="text-green-700 text-sm">{{ frontend_framework | default("Next.js") }} + TypeScript</p>
+              <p className="text-green-700 text-sm">Puerto: {{ frontend_port | default(3000) }}</p>
+            </div>
+
+            {/* Backend Status */}
+            <div className={`bg-white rounded-lg shadow-lg p-6 border-l-4 ${
+              loading ? 'border-yellow-500' : error ? 'border-red-500' : 'border-green-500'
+            }`}>
+              <h3 className={`text-lg font-semibold mb-2 ${
+                loading ? 'text-yellow-800' : error ? 'text-red-800' : 'text-green-800'
+              }`}>
+                {loading ? '🔄' : error ? '❌' : '✅'} Backend API
+              </h3>
+              {loading ? (
+                <p className="text-yellow-700 text-sm">Conectando...</p>
+              ) : error ? (
+                <p className="text-red-700 text-sm">Error: {error}</p>
+              ) : (
+                <div>
+                  <p className="text-green-700 text-sm">{{ backend_framework | default("FastAPI") }} funcionando</p>
+                  <p className="text-green-700 text-sm">Puerto: {{ backend_port | default(8000) }}</p>
+                </div>
+              )}
+            </div>
+
+            {/* Database Status */}
+            <div className="bg-white rounded-lg shadow-lg p-6 border-l-4 border-blue-500">
+              <h3 className="text-lg font-semibold text-blue-800 mb-2">
+                🗄️ Database
+              </h3>
+              <p className="text-blue-700 text-sm">{{ database | default("PostgreSQL") }}</p>
+              <p className="text-blue-700 text-sm">Puerto: {{ database_port | default(5432) }}</p>
+            </div>
+          </div>
+
+          {/* API Response */}
+          {!loading && !error && apiData && (
+            <div className="bg-white rounded-lg shadow-lg p-6 mb-8">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4">
+                📡 Respuesta del Backend
+              </h3>
+              <div className="bg-gray-50 rounded p-4">
+                <pre className="text-sm text-gray-700">
+                  {JSON.stringify(apiData, null, 2)}
+                </pre>
+              </div>
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+            <a 
+              href="{{ api_url | default('http://localhost:8000') }}/docs"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-blue-600 text-white px-6 py-3 rounded-lg text-center hover:bg-blue-700 transition-colors font-medium"
+            >
+              📚 API Documentation
+            </a>
+            
+            {% if monitoring_enabled %}
+            <a 
+              href="http://localhost:{{ grafana_port | default(3001) }}"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-orange-600 text-white px-6 py-3 rounded-lg text-center hover:bg-orange-700 transition-colors font-medium"
+            >
+              📊 Grafana Dashboard
+            </a>
+            
+            <a 
+              href="http://localhost:{{ prometheus_port | default(9090) }}"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-red-600 text-white px-6 py-3 rounded-lg text-center hover:bg-red-700 transition-colors font-medium"
+            >
+              🔍 Prometheus
+            </a>
+            {% endif %}
+          </div>
+
+          {/* Stack Information */}
+          {% if show_stack_info %}
+          <div className="bg-white rounded-lg shadow-lg p-6 mb-8">
+            <h3 className="text-lg font-semibold text-gray-800 mb-4">
+              🛠️ Stack Tecnológico
+            </h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+              <div>
+                <p className="font-medium text-gray-700">Frontend:</p>
+                <p className="text-gray-600">{{ frontend_framework | default("Next.js") }}</p>
+                <p className="text-gray-600">TypeScript</p>
+                <p className="text-gray-600">{{ styling | default("Tailwind CSS") }}</p>
+              </div>
+              <div>
+                <p className="font-medium text-gray-700">Backend:</p>
+                <p className="text-gray-600">{{ backend_framework | default("FastAPI") }}</p>
+                <p className="text-gray-600">{{ orm | default("SQLAlchemy") }}</p>
+                <p className="text-gray-600">Pydantic</p>
+              </div>
+              <div>
+                <p className="font-medium text-gray-700">Database:</p>
+                <p className="text-gray-600">{{ database | default("PostgreSQL") }}</p>
+                {% if cache_enabled %}
+                <p className="text-gray-600">{{ cache | default("Redis") }}</p>
+                {% endif %}
+              </div>
+              <div>
+                <p className="font-medium text-gray-700">DevOps:</p>
+                <p className="text-gray-600">Docker</p>
+                {% if proxy_enabled %}
+                <p className="text-gray-600">{{ proxy | default("Nginx") }}</p>
+                {% endif %}
+                {% if monitoring_enabled %}
+                <p className="text-gray-600">Prometheus</p>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+          {% endif %}
+
+          {/* Footer */}
+          <div className="text-center text-gray-500 text-sm">
+            <p>🚀 Generado por Genesis Engine</p>
+            <p>Proyecto: {{ project_name }} | Versión: {{ version | default("1.0.0") }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `page.tsx.j2` template with a full-featured home page

## Testing
- `pytest -q` *(fails: AssertionError in `mi-app/backend/app/tests/test_main.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6871e9d6ecac832580c970e76903199b