### PR TITLE
Enable versioned API router in example backend

### DIFF
--- a/mi-app/backend/app/main.py
+++ b/mi-app/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from app.routes import api
 
 app = FastAPI(
     title="mi-app API",
@@ -16,11 +17,14 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Include API router
+app.include_router(api.router, prefix="/api/v1", tags=["API"])
+
 @app.get("/")
 def read_root():
     return {
-        "message": "Welcome to mi-app",
-        "status": "running",
+        "message": "Genesis API is running",
+        "status": "healthy",
         "docs": "/docs"
     }
 


### PR DESCRIPTION
## Summary
- expose `/api/v1` endpoints for mi-app example backend
- register the `api` router so tests pass

## Testing
- `pytest -q mi-app/backend/app/tests/test_main.py -q`
- `pytest -q` *(fails: async tasks and deploy tests)*

------
https://chatgpt.com/codex/tasks/task_e_6871eb6ffc9c8325bcf11b0953bae9a5