### PR TITLE
Add test for fastapi main generation

### DIFF
--- a/tests/test_backend_generation.py
+++ b/tests/test_backend_generation.py
@@ -246,3 +246,22 @@ def test_generate_config_file_uses_pydantic_settings():
     config_content = agent._generate_config_file(schema)
     assert 'from pydantic_settings import BaseSettings' in config_content
 
+
+def test_generate_fastapi_main_includes_project_name(tmp_path):
+    agent = make_agent()
+    config = BackendConfig(
+        framework=BackendFramework.FASTAPI,
+        database=DatabaseType.POSTGRESQL,
+        auth_method=AuthMethod.JWT,
+        features=[],
+        dependencies=[],
+        environment_vars={},
+    )
+    config.project_name = 'DemoApp'
+    config.description = 'Demo description'
+    agent._generate_fastapi_main(config, tmp_path)
+
+    main_file = tmp_path / 'app' / 'main.py'
+    assert main_file.exists()
+    assert 'DemoApp' in main_file.read_text()
+


### PR DESCRIPTION
## Summary
- verify that `_generate_fastapi_main` embeds the configured project name

## Testing
- `pytest tests/test_backend_generation.py::test_generate_fastapi_main_includes_project_name -q`
- `pytest tests/test_backend_generation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687203811cac83259c6f9842226bc5eb