### PR TITLE
Fix docker-compose backend default

### DIFF
--- a/genesis_engine/agents/devops.py
+++ b/genesis_engine/agents/devops.py
@@ -570,7 +570,7 @@ jobs:
             "backend_dockerfile_exists": dockerfile_status.get("backend_dockerfile", False),
             "frontend_dockerfile_exists": dockerfile_status.get("frontend_dockerfile", False),
             # Siempre incluir servicios de backend y frontend
-            "include_backend": bool(stack.get("backend")),
+            "include_backend": bool(stack.get("backend")) if "backend" in stack else True,
             "include_frontend": bool(stack.get("frontend")),
             # NUEVAS VARIABLES para evitar errores
             "version": "1.0.0",


### PR DESCRIPTION
## Summary
- ensure backend service is included by default when schema stack omits backend
- test orchestrator validation on projects with missing backend stack info

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687208913c248325895a2e6405892f03