### PR TITLE
Add basic docs

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,11 @@
+# Arquitectura de Agentes
+
+Genesis Engine se compone de varios agentes especializados que colaboran para generar un proyecto completo.
+
+- **ArchitectAgent**: diseña la arquitectura y define las entidades.
+- **BackendAgent**: produce el código del backend y la base de datos.
+- **FrontendAgent**: genera la interfaz de usuario.
+- **DevOpsAgent**: configura contenedores y pipelines de CI/CD.
+- **DeployAgent**: orquesta el despliegue de la aplicación.
+
+Cada agente se comunica mediante el protocolo MCP descrito en `docs/mcp-protocol.md`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,8 @@
+# Referencia de API
+
+La API de **Genesis Engine** se genera de forma dinámica una vez creado un proyecto.
+
+- La documentación interactiva se expone automáticamente en `/docs` cuando se ejecuta la aplicación.
+- Las rutas y modelos dependen de las entidades definidas por el usuario.
+
+Para información completa revisa los archivos generados en el directorio `backend/` de tu proyecto.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,18 @@
+# Despliegue en Producción
+
+Genesis Engine permite desplegar las aplicaciones generadas en distintos entornos.
+
+## Despliegue Local
+
+```bash
+genesis deploy --local --prod
+```
+
+## Despliegue en Cloud
+
+```bash
+# Ejemplo para AWS
+genesis deploy --cloud=aws --region=us-east-1
+```
+
+Consulta las opciones avanzadas en `genesis deploy --help` para adaptar el despliegue a tu infraestructura.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,21 @@
+# Guía de Instalación
+
+Esta guía describe los pasos básicos para instalar **Genesis Engine** en tu entorno local.
+
+1. Asegúrate de tener Python 3.9+ y Node.js 18+ instalados.
+2. Clona el repositorio y navega al directorio del proyecto:
+   ```bash
+   git clone https://github.com/genesis-engine/genesis-engine.git
+   cd genesis-engine
+   ```
+3. Instala las dependencias principales:
+   ```bash
+   pip install -e .
+   ```
+4. Comprueba la instalación ejecutando:
+   ```bash
+   genesis --version
+   genesis doctor
+   ```
+
+Para un entorno de contribución consulta `CONTRIBUTING.md`.

--- a/docs/mcp-protocol.md
+++ b/docs/mcp-protocol.md
@@ -1,0 +1,18 @@
+# Protocolo MCP
+
+El *Multi-agent Communication Protocol* (MCP) define el formato de los mensajes y el flujo de interacción entre los agentes de Genesis Engine.
+
+Un mensaje típico incluye:
+
+```json
+{
+  "sender": "architect_agent",
+  "recipient": "backend_agent",
+  "action": "generate_backend",
+  "params": {
+    "schema": "..."
+  }
+}
+```
+
+Los agentes procesan los mensajes de manera asíncrona y devuelven la respuesta correspondiente para continuar el pipeline de generación.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,21 @@
+# Tutorial Paso a Paso
+
+Este tutorial muestra de forma resumida cómo iniciar un proyecto con **Genesis Engine**.
+
+1. Ejecuta el comando de ayuda para conocer las opciones disponibles:
+   ```bash
+   genesis help
+   ```
+2. Crea una aplicación SaaS básica utilizando el template incluido:
+   ```bash
+   genesis init my-saas-app \
+     --template=saas-basic
+   ```
+3. Inicia los servicios en modo desarrollo:
+   ```bash
+   cd my-saas-app
+   docker-compose up -d
+   ```
+4. Accede a `http://localhost:3000` para el frontend y `http://localhost:8000/docs` para la API.
+
+Consulta el resto de la documentación para detalles avanzados.


### PR DESCRIPTION
## Summary
- add missing documentation files in `docs/`
- keep `docs/templates.md` link intact

## Testing
- `pip install -e .`
- `pytest -q` *(fails: 23 failed, 51 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687406aea000832585f26ff06eafd87c