### PR TITLE
Fix doc references to removed scripts

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -65,9 +65,8 @@ genesis init mi-app --template=saas-basic
 
 ### Error de encoding en Windows
 ```bash
-# Verificar encoding
-python apply_final_fixes.py
-python verify_fixes.py
+# Verificar que todos los archivos usen UTF-8
+git config --global core.autocrlf false
 ```
 
 ### Error de Pydantic


### PR DESCRIPTION
## Summary
- remove unused Windows fix scripts from Quick Start doc

## Testing
- `pytest tests/test_cli_help.py::test_help_command -q`

------
https://chatgpt.com/codex/tasks/task_e_687406affca48325b87b4039cb319a91