### PR TITLE
Update docs for repo split

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -3,12 +3,15 @@
 ## Instalación
 
 ```bash
-# Clonar repositorio
-git clone https://github.com/genesis-engine/genesis-engine.git
-cd genesis-engine
+# Clonar repos principales
+git clone https://github.com/genesis-engine/genesis-core.git
+git clone https://github.com/genesis-engine/genesis-cli.git
+git clone https://github.com/genesis-engine/genesis-templates.git
 
-# Instalar Genesis Engine
-pip install -e .  # incluye dependencias como PyYAML
+# Instalar componentes
+pip install -e genesis-core
+pip install -e genesis-cli
+pip install -e genesis-templates
 
 # Verificar instalación
 genesis --version

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Estas partes pueden cambiar sin previo aviso y es posible que presenten
 comportamientos inesperados. Consulta la sección de [Roadmap](#-roadmap) para
 conocer las características que llegarán próximamente.
 
+## 📦 Repositorios Separados
+
+A partir de la versión 1.1 el proyecto se divide en varios repositorios:
+
+- [`genesis-core`](https://github.com/genesis-engine/genesis-core) – lógica de orquestación y agentes base.
+- [`genesis-cli`](https://github.com/genesis-engine/genesis-cli) – interfaz de línea de comandos.
+- [`genesis-templates`](https://github.com/genesis-engine/genesis-templates) – plantillas oficiales.
+- [`genesis-examples`](https://github.com/genesis-engine/genesis-examples) – proyectos de ejemplo.
+
+Cada componente se versiona por separado y puede instalarse de forma independiente.
+
 ## 🚀 Instalación Rápida
 
 ### Prerrequisitos
@@ -81,12 +92,15 @@ conocer las características que llegarán próximamente.
 ### Instalación
 
 ```bash
-# Clonar repositorio
-git clone https://github.com/genesis-engine/genesis-engine.git
-cd genesis-engine
+# Clonar repositorios principales
+git clone https://github.com/genesis-engine/genesis-core.git
+git clone https://github.com/genesis-engine/genesis-cli.git
+git clone https://github.com/genesis-engine/genesis-templates.git
 
-# Instalar Genesis Engine
-pip install -e .  # instala dependencias como PyYAML
+# Instalar cada componente
+pip install -e genesis-core
+pip install -e genesis-cli
+pip install -e genesis-templates
 
 # Verificar instalación
 genesis --version
@@ -363,6 +377,22 @@ async def architect_to_backend():
     return response.result
 ```
 
+### Uso de `GenesisOrchestrator` con MCPturbo
+
+```python
+from mcpturbo.protocol import TurboProtocol
+from genesis_core.orchestrator import GenesisOrchestrator
+
+turbo = TurboProtocol()
+orchestrator = GenesisOrchestrator()
+orchestrator.mcp = turbo
+
+result = await orchestrator.create_project({
+    "name": "demo",
+    "template": "saas-basic"
+})
+```
+
 ### Flujo de Trabajo
 
 ```mermaid
@@ -561,6 +591,7 @@ async def custom_post_processing(context):
 - **[Templates y Plantillas](docs/templates.md)**
 - **[Despliegue en Producción](docs/deployment.md)**
 - **[Guía de Contribución](CONTRIBUTING.md)**
+- **[Guía de Migración](docs/migration.md)**
 
 ### Ejemplos
 
@@ -576,14 +607,18 @@ Genesis Engine es un proyecto open source. ¡Las contribuciones son bienvenidas!
 ### Desarrollo Local
 
 ```bash
-# Clonar repo
-git clone https://github.com/genesis-engine/genesis-engine.git
-cd genesis-engine
+# Clonar repos principales
+git clone https://github.com/genesis-engine/genesis-core.git
+git clone https://github.com/genesis-engine/genesis-cli.git
+git clone https://github.com/genesis-engine/genesis-templates.git
+cd genesis-core  # ruta para el core
 
 # Setup desarrollo
 python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
-pip install -e ".[dev]"
+pip install -e .[dev]
+pip install -e ../genesis-cli
+pip install -e ../genesis-templates
 
 # Ejecutar tests
 pytest

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,14 +3,18 @@
 Esta guía describe los pasos básicos para instalar **Genesis Engine** en tu entorno local.
 
 1. Asegúrate de tener Python 3.9+ y Node.js 18+ instalados.
-2. Clona el repositorio y navega al directorio del proyecto:
+2. Clona los repositorios principales y navega al directorio del core:
    ```bash
-   git clone https://github.com/genesis-engine/genesis-engine.git
-   cd genesis-engine
+   git clone https://github.com/genesis-engine/genesis-core.git
+   git clone https://github.com/genesis-engine/genesis-cli.git
+   git clone https://github.com/genesis-engine/genesis-templates.git
+   cd genesis-core
    ```
 3. Instala las dependencias principales:
    ```bash
    pip install -e .
+   pip install -e ../genesis-cli
+   pip install -e ../genesis-templates
    ```
 4. Comprueba la instalación ejecutando:
    ```bash

--- a/docs/mcp-protocol.md
+++ b/docs/mcp-protocol.md
@@ -16,3 +16,19 @@ Un mensaje típico incluye:
 ```
 
 Los agentes procesan los mensajes de manera asíncrona y devuelven la respuesta correspondiente para continuar el pipeline de generación.
+
+## Ejemplo de uso con GenesisOrchestrator y MCPturbo
+
+```python
+import asyncio
+from mcpturbo.protocol import TurboProtocol
+from genesis_core.orchestrator import GenesisOrchestrator
+
+async def main():
+    turbo = TurboProtocol()
+    orchestrator = GenesisOrchestrator()
+    orchestrator.mcp = turbo
+    await orchestrator.create_project({"name": "demo", "template": "saas-basic"})
+
+asyncio.run(main())
+```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,27 @@
+# Guía de Migración desde la versión monolítica
+
+A partir de la versión 1.1, Genesis Engine se divide en varios repositorios independientes.
+Si aún utilizas el paquete monolítico `genesis-engine`, sigue estos pasos para actualizarte:
+
+1. Desinstala el paquete antiguo:
+   ```bash
+   pip uninstall genesis-engine
+   ```
+2. Clona los nuevos repositorios y entra al directorio del core:
+   ```bash
+   git clone https://github.com/genesis-engine/genesis-core.git
+   git clone https://github.com/genesis-engine/genesis-cli.git
+   git clone https://github.com/genesis-engine/genesis-templates.git
+   cd genesis-core
+   ```
+3. Instala cada componente de forma editable (o desde PyPI si lo prefieres):
+   ```bash
+   pip install -e .
+   pip install -e ../genesis-cli
+   pip install -e ../genesis-templates
+   ```
+4. Actualiza tus scripts o automatizaciones para importar desde `genesis_core` en lugar de `genesis_engine`.
+   El uso básico del CLI no cambia.
+
+Tras la migración podrás seguir ejecutando `genesis` normalmente, pero ahora cada
+módulo evoluciona con su propio ciclo de versiones.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,6 +1,7 @@
 # Tutorial Paso a Paso
 
 Este tutorial muestra de forma resumida cómo iniciar un proyecto con **Genesis Engine**.
+Recuerda que el CLI ahora vive en el repositorio [`genesis-cli`](https://github.com/genesis-engine/genesis-cli).
 
 1. Ejecuta el comando de ayuda para conocer las opciones disponibles:
    ```bash


### PR DESCRIPTION
## Summary
- update README with split repositories and MCPturbo usage
- update quick start and installation docs
- note CLI repo in tutorial and add MCPturbo example in protocol docs
- add migration guide from old monolithic package

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c725e3e08325966de7b2da155662